### PR TITLE
refectoring: added next status to status changes

### DIFF
--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -37,6 +37,14 @@ models:
         description: "Previous status for the same charge point and connector (null for first status)"
       - name: previous_ingested_timestamp
         description: "Timestamp of the previous status notification for the same charge point and connector (null for first status)"
+      - name: next_status
+        description: "Next status for the same charge point and connector (null for last status)"
+      - name: next_ingested_timestamp
+        description: "Timestamp of the next status notification for the same charge point and connector (null for last status)"
+      - name: seconds_to_previous_status
+        description: "Time in seconds from previous status to current status (null if no previous status)"
+      - name: seconds_to_next_status
+        description: "Time in seconds from current status to next status (null if no next status)"
       - name: confirmation_ingested_timestamp
         description: "Timestamp when the confirmation was ingested"
     tests:


### PR DESCRIPTION
Trying to defind boundaries for how far back and after to look for triggers. For status changes could be before previous status and next status.