### PR TITLE
status changes bug fix

### DIFF
--- a/models/intermediate/int_status_changes.sql
+++ b/models/intermediate/int_status_changes.sql
@@ -106,6 +106,13 @@
         from status_with_confirmation
     ),
 
+    change_from_lag as (
+        select *
+        from status_with_lag
+        where previous_status is null or previous_status <> status
+    ),
+
+
     -- Add next status using window function
     status_with_lead as (
         select
@@ -116,7 +123,7 @@
             lead(ingested_ts) over (
                 partition by charge_point_id, connector_id order by ingested_ts
             ) as next_ingested_ts
-        from status_with_lag
+        from change_from_lag
     ),
 
     statuses as (
@@ -139,4 +146,4 @@
  select *,
     (select incremental_ts from incremental) as incremental_ts
  from statuses
- where previous_status is null or previous_status <> status
+ 

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -54,3 +54,13 @@ models:
               - charge_point_id
               - connector_id
               - ingested_ts
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "status != previous_status or previous_status is null"
+          config:
+            severity: error
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "status != next_status or next_status is null"
+          config:
+            severity: error

--- a/seeds/ocpp_1_6_synthetic_logs_1d.csv
+++ b/seeds/ocpp_1_6_synthetic_logs_1d.csv
@@ -7,6 +7,8 @@ timestamp,id,action,msg
 2025-08-18T12:00:02.040Z,CH-001,,"[3,""notif-6c2c3"",{}]"
 2025-08-18T12:00:03.000Z,CH-001,StatusNotification,"[2,""notif-0d466"",""StatusNotification"",{""connectorId"":3,""status"":""Available"",""errorCode"":""NoError"",""timestamp"":""2025-08-18T12:00:03.000Z""}]"
 2025-08-18T12:00:03.040Z,CH-001,,"[3,""notif-0d466"",{}]"
+2025-08-18T12:00:03.001Z,CH-001,StatusNotification,"[2,""notif-0d4661"",""StatusNotification"",{""connectorId"":3,""status"":""Available"",""errorCode"":""NoError"",""timestamp"":""2025-08-18T12:00:03.001Z""}]"
+2025-08-18T12:00:03.041Z,CH-001,,"[3,""notif-0d4661"",{}]"
 2025-08-18T12:00:04.000Z,CH-001,StatusNotification,"[2,""notif-a6e80"",""StatusNotification"",{""connectorId"":4,""status"":""Available"",""errorCode"":""NoError"",""timestamp"":""2025-08-18T12:00:04.000Z""}]"
 2025-08-18T12:00:04.040Z,CH-001,,"[3,""notif-a6e80"",{}]"
 2025-08-18T12:00:05.000Z,CH-001,Heartbeat,"[2,""hb-e1c51"",""Heartbeat"",{}]"


### PR DESCRIPTION
Did not check for the next status to be a change.

Ex:

```
select ingested_ts, previous_status, status, next_status 
from dbt_dev1.int_status_changes
where connector_id = 3
order by ingested_ts asc;
```

Before:

| INGESTED_TS             | PREVIOUS_STATUS | STATUS     | NEXT_STATUS |
|--------------------------|-----------------|------------|-------------|
| 2025-08-18 12:00:03.000 |                 | Available  | Available   |
| 2025-08-18 12:23:35.000 | Available       | Preparing  | Charging    |
| 2025-08-18 12:23:37.000 | Preparing       | Charging   | Available   |
| 2025-08-18 12:25:36.000 | Charging        | Available  |             |

After:
| INGESTED_TS             | PREVIOUS_STATUS | STATUS     | NEXT_STATUS |
|--------------------------|-----------------|------------|-------------|
| 2025-08-18 12:00:03.000 |                 | Available  | Preparing   |
| 2025-08-18 12:23:35.000 | Available       | Preparing  | Charging    |
| 2025-08-18 12:23:37.000 | Preparing       | Charging   | Available   |
| 2025-08-18 12:25:36.000 | Charging        | Available  |             |

