### PR TITLE
stitching statuses across incrememntal runs

### DIFF
--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: int_status_changes
-    description: "Intermediate model that tracks connector status changes with previous status tracking and confirmation status. Grain: one row per status notification."
+    description: "Intermediate model that tracks connector status changes with previous status tracking and confirmation status. Uses incremental processing with 30-minute buffer to ensure accurate previous_status relationships. Grain: one row per status notification."
     columns:
       - name: charge_point_id
         description: "Identifier for the charge point"


### PR DESCRIPTION
Summary
This PR enhances the int_status_changes model to handle incremental processing more accurately by implementing a buffer window approach that preserves lag/lead relationships across batch boundaries. The solution addresses the critical issue where previous_status and next_status could be incorrect due to incomplete window function context in incremental runs.

Problem
Previously, when int_status_changes ran incrementally, the window functions (lag() and lead()) only operated on the current batch of data. This caused several issues:
Incomplete Previous Status: Records at the start of a batch couldn't find their actual previous status (it was in a previous batch)
Incomplete Next Status: Records at the end of a batch couldn't find their actual next status (it would be in a future batch)
Incorrect Lag/Lead Values: Window functions returned incorrect relationships due to missing historical context

Solution
Implemented a buffer window approach that:
Reads 30-minute buffer from the existing table to extend lag window context
Uses coalesce logic to prefer existing lag values over recalculated ones
Self-healing mechanism where missing next_status values get updated in subsequent runs
Cross-platform type safety using dbt type macros