### PR TITLE
charge attempts / macros

### DIFF
--- a/macros/array_concat.sql
+++ b/macros/array_concat.sql
@@ -1,0 +1,35 @@
+{% macro array_concat(array_a, array_b) %}
+    {#
+      Null-aware concat:
+      - both NULL  -> NULL
+      - a NULL     -> b
+      - b NULL     -> a
+      - else       -> concat(a,b)
+      Example: {{ array_concat('a_col', 'b_col') }}.
+    #}
+    {% if target.type == "snowflake" %}
+        {% set _concat = "array_cat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% elif target.type in ["postgres", "redshift"] %}
+        {% set _concat = "array_cat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% elif target.type == "bigquery" %}
+        {% set _concat = "array_concat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% elif target.type in ["spark", "databricks"] %}
+        {% set _concat = "array_concat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% elif target.type in ["trino", "presto", "athena"] %}
+        {% set _concat = "concat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% elif target.type == "duckdb" %}
+        {% set _concat = "list_concat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% else %} 
+        {% set _concat = "concat(" ~ array_a ~ ", " ~ array_b ~ ")" %}
+    {% endif %}
+
+    case
+        when {{ array_a }} is null and {{ array_b }} is null
+            then null
+        when {{ array_a }} is null
+            then {{ array_b }}
+        when {{ array_b }} is null
+            then {{ array_a }}
+        else {{ _concat }}
+    end
+{% endmacro %}

--- a/macros/array_contains.sql
+++ b/macros/array_contains.sql
@@ -1,0 +1,23 @@
+{% macro array_contains(array_column, value) %}
+    {#
+      Platform-invariant array contains function:
+      - Checks if a value exists in an array column
+      - Handles different SQL dialects for array operations
+      Example: {{ array_contains('my_array_col', 'search_value') }}
+    #}
+    {% if target.type == "snowflake" %}
+        array_contains({{ value }}::variant,{{ array_column }})
+    {% elif target.type in ["postgres", "redshift"] %}
+        {{ value }} = any({{ array_column }})
+    {% elif target.type == "bigquery" %}
+        {{ value }} in unnest({{ array_column }})
+    {% elif target.type in ["spark", "databricks"] %}
+        array_contains({{ array_column }}, {{ value }})
+    {% elif target.type in ["trino", "presto", "athena"] %}
+        contains({{ array_column }}, {{ value }})
+    {% elif target.type == "duckdb" %}
+        list_contains({{ array_column }}, {{ value }})
+    {% else %} 
+        {{ value }} = any({{ array_column }})
+    {% endif %}
+{% endmacro %}

--- a/macros/array_size.sql
+++ b/macros/array_size.sql
@@ -1,0 +1,9 @@
+{% macro array_size(array_column) %}
+    {% if target.type == 'snowflake' %}
+        array_size({{ array_column }})
+    {% elif target.type == 'redshift' %}
+        get_array_length({{ array_column }})
+    {% else %}
+        cardinality({{ array_column }})
+    {% endif %}
+{% endmacro %}

--- a/macros/payload_extractions.sql
+++ b/macros/payload_extractions.sql
@@ -1,0 +1,99 @@
+{% macro payload_extract_id_tag(action, payload, conf_payload) %}
+    case 
+        when {{ action }} in ('StartTransaction', 'RemoteStartTransaction') 
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="idTag") }} as {{ dbt.type_string() }})
+        when {{ action }} = 'Authorize'
+            then cast({{ fivetran_utils.json_extract(string=conf_payload, string_path="idTagInfo.idTag") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_id_tag_status(action, conf_payload) %}
+    case
+        when {{ action }} in ('StartTransaction', 'Authorize') 
+            then cast({{ fivetran_utils.json_extract(string=conf_payload, string_path="idTagInfo.status") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_transaction_start_ts(action, payload) %}
+    case 
+        when {{ action }} = 'StartTransaction'
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="timestamp") }} as {{ dbt.type_timestamp() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_transaction_stop_ts(action, payload) %}
+    case 
+        when {{ action }} = 'StopTransaction'
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="timestamp") }} as {{ dbt.type_timestamp() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_meter_start(action, payload) %}
+    case 
+        when {{ action }} = 'StartTransaction' 
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="meterStart") }} as {{ dbt.type_numeric() }})
+        else null    
+    end
+{% endmacro %}
+
+{% macro payload_extract_meter_stop(action, payload) %}
+    case
+        when {{ action }} = 'StopTransaction' 
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="meterStop") }} as {{ dbt.type_numeric() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_transaction_stop_reason(action, payload) %}
+    case 
+        when {{ action }} = 'StopTransaction' 
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="reason") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_transaction_id(action, payload, conf_payload) %}
+    case 
+        when {{ action }} in ('StopTransaction', 'RemoteStopTransaction', 'MeterValues') 
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="transactionId") }} as {{ dbt.type_string() }})
+        when {{ action }} = 'StartTransaction'
+            then cast({{ fivetran_utils.json_extract(string=conf_payload, string_path="transactionId") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_meter_value(action, conf_payload) %}
+    case
+        when {{ action }} = 'MeterValues'
+            then cast({{ fivetran_utils.json_extract(string=conf_payload, string_path="meterValue") }} as {{ dbt.type_numeric() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_error_code(action, payload) %}
+    case
+        when {{ action }} = 'StatusNotification'
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="errorCode") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_connector_id(action, payload) %}
+    case 
+        when {{ action }} in ('StatusNotification', 'StartTransaction', 'MeterValues', 'RemoteStartTransaction')
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="connectorId") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}
+
+{% macro payload_extract_status(action, payload) %}
+    case 
+        when {{ action }} = 'StatusNotification'
+            then cast({{ fivetran_utils.json_extract(string=payload, string_path="status") }} as {{ dbt.type_string() }})
+        else null
+    end
+{% endmacro %}

--- a/models/intermediate/int_status_changes.sql
+++ b/models/intermediate/int_status_changes.sql
@@ -81,9 +81,9 @@
             unique_id,
             action,
             payload,
-            {{ fivetran_utils.json_extract(string="payload", string_path="connectorId")}} as connector_id,
-            {{ fivetran_utils.json_extract(string="payload", string_path="status") }} as status,
-            {{ fivetran_utils.json_extract(string="payload", string_path="errorCode") }} as error_code
+            {{ payload_extract_connector_id('action', 'payload') }} as connector_id,
+            {{ payload_extract_status('action', 'payload') }} as status,
+            {{ payload_extract_error_code('action', 'payload') }} as error_code
         from ocpp_logs
         where action = 'StatusNotification'
             and message_type_id = {{ var("message_type_ids").CALL }}


### PR DESCRIPTION
Building toward a model that represents individual charge attempts.
The original idea was to track connectors entering the Preparing state, but to account for cases like offline charging, the model will also allow standalone transactions to represent a charge attempt.

<img width="1168" height="373" alt="Screenshot 2025-10-09 at 10 23 55 PM" src="https://github.com/user-attachments/assets/15aeed07-6297-4f8f-b669-de10cb193621" />

This PR is 1/4 to add macros  that works across different SQL platforms (Snowflake, PostgreSQL, BigQuery, etc.)
- [x]  macros
- [ ] intermediate connector preparing model - a context of everything that happened before and after preparing state (statuses, transations) [15](https://github.com/appspace/kwwhat/pull/15)
- [ ] intermediate transactions - an aggregate model of transactions [16](https://github.com/appspace/kwwhat/pull/16)
- [ ] attemps model as a join of preparing context to transactions, aloowing for lone transactions [17](https://github.com/appspace/kwwhat/pull/17)