### PR TITLE
charge attempts / transactions

### DIFF
--- a/models/intermediate/int_transactions.sql
+++ b/models/intermediate/int_transactions.sql
@@ -1,0 +1,223 @@
+{{
+  config(
+    materialized='incremental',
+    unique_key=["charge_point_id", "connector_id", "ingested_ts"], 
+    incremental_strategy="merge",
+    cluster_by="ingested_ts"
+  )
+}}
+
+{% set transaction_related_actions = ['StartTransaction', 'StopTransaction', 'RemoteStartTransaction', 'RemoteStopTransaction', 'MeterValues'] %}
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("month", 3, "from_timestamp") }} as to_timestamp
+        from
+            (
+                select (select max(incremental_ts) from {{ this }}) as from_timestamp
+            )
+    ),
+
+{% else %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("month", 3, "from_timestamp") }} as to_timestamp
+        from
+            (
+                select cast( '{{ var("start_processing_date") }}' as {{ dbt.type_timestamp() }}) as from_timestamp
+            )
+    ),
+{% endif %}
+
+ocpp_logs as (
+    select
+        charge_point_id,
+        action,
+        ingested_timestamp as ingested_ts,
+        message_type_id,
+        payload,
+        unique_id
+    from {{ ref("stg_ocpp_logs") }}
+    where ingested_timestamp > (select from_timestamp from incremental_date_range)
+        and ingested_timestamp <= (select to_timestamp from incremental_date_range)
+),
+
+incremental as (
+    select
+        max(ingested_ts) as incremental_ts
+    from ocpp_logs
+),
+
+-- Filter for charge attempt actions first
+transaction_events as (
+    select
+        charge_point_id,
+        action,
+        ingested_ts,
+        message_type_id,
+        payload,
+        unique_id,
+        {{ payload_extract_connector_id('action', 'payload') }} as connector_id
+    from ocpp_logs
+    where action in ({{ "'" + "', '".join(transaction_related_actions) + "'" }})
+),
+
+transaction_events_conf as (
+    select req.*,
+        conf.payload as conf_payload
+    from transaction_events req
+    left join ocpp_logs conf on req.unique_id = conf.unique_id
+        and conf.message_type_id = {{ var("message_type_ids").CALLRESULT }}
+        and conf.ingested_ts >= req.ingested_ts
+        and conf.ingested_ts <= {{ dbt.dateadd("second", 15, "req.ingested_ts") }}
+
+),
+
+-- Extract relevant details based on action type
+transaction_details as (
+    select
+        -- Charge attempts details
+        e.charge_point_id,
+        e.connector_id,
+        e.ingested_ts,
+
+        {{ payload_extract_transaction_id('action', 'payload', 'conf_payload') }} as transaction_id,
+        -- Extract details based on action type using reusable macros
+        {{ payload_extract_id_tag('action', 'payload', 'conf_payload') }} as id_tag,
+        {{ payload_extract_id_tag_status('action', 'conf_payload') }} as id_tag_status,
+        -- Transaction details
+        {{ payload_extract_transaction_start_ts('action', 'payload') }} as transaction_start_ts,
+        {{ payload_extract_transaction_stop_ts('action', 'payload') }} as transaction_stop_ts,
+        {{ payload_extract_transaction_stop_reason('action', 'payload') }} as transaction_stop_reason,
+        -- Meter details
+        {{ payload_extract_meter_start('action', 'payload') }} as meter_start,
+        {{ payload_extract_meter_stop('action', 'payload') }} as meter_stop,
+        {{ payload_extract_meter_value('action', 'payload') }} as meter_value,
+    from transaction_events_conf e
+),
+
+-- Group by transaction_id and extract transaction-level details
+transactions as (
+    select
+        transaction_id,
+        charge_point_id,
+
+        array_distinct({{ fivetran_utils.array_agg(field_to_agg="connector_id") }}) as connector_ids,
+        
+        -- Transaction timing details
+        min(ingested_ts) as ingested_ts,
+        min(transaction_start_ts) as transaction_start_ts,
+        max(transaction_stop_ts) as transaction_stop_ts,
+        max(ingested_ts) as last_ingested_ts,
+        min(transaction_stop_reason) as transaction_stop_reason,
+        
+        --Authentication details
+        array_distinct({{ fivetran_utils.array_agg(field_to_agg="id_tag") }}) as id_tags,
+        array_distinct({{ fivetran_utils.array_agg(field_to_agg="id_tag_status") }}) as id_tag_statuses,
+        
+        -- Energy transfer details
+        min(meter_start) as meter_start_wh,
+        max(meter_stop) as meter_stop_wh
+        
+    from transaction_details
+    where transaction_id is not null
+    group by 
+        transaction_id,
+        charge_point_id
+),
+
+status_notifications as (
+    select
+        charge_point_id,
+        ingested_ts,
+        {{ payload_extract_connector_id('action', 'payload') }} as connector_id,
+        {{ payload_extract_error_code('action', 'payload') }} as error_code
+    from ocpp_logs
+    where action = 'StatusNotification'
+        and message_type_id = {{ var("message_type_ids").CALL }}
+),
+
+-- Join StatusNotification events that occurred during each transaction
+transaction_status_notifications as (
+    select
+        t.transaction_id,
+        t.charge_point_id,
+        array_distinct({{ fivetran_utils.array_agg(field_to_agg="sn.error_code") }}) as error_codes
+    from transactions t
+    left join status_notifications sn
+        on t.charge_point_id = sn.charge_point_id
+        and sn.ingested_ts >= t.transaction_start_ts
+        and sn.ingested_ts <= coalesce(t.transaction_stop_ts, t.last_ingested_ts)
+        and {{ array_contains('t.connector_ids', 'sn.connector_id') }}
+    group by 
+        t.transaction_id,
+        t.charge_point_id
+)
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+,
+
+combined_transactions as (
+    select
+        n.charge_point_id,
+        n.transaction_id,
+        coalesce(b.ingested_ts, n.ingested_ts) as ingested_ts,
+        coalesce(b.transaction_start_ts, n.transaction_start_ts) as transaction_start_ts,
+        coalesce(b.transaction_stop_ts, n.transaction_stop_ts) as transaction_stop_ts,
+        coalesce(b.last_ingested_ts, n.last_ingested_ts) as last_ingested_ts,
+        coalesce(b.transaction_stop_reason, n.transaction_stop_reason) as transaction_stop_reason,
+        coalesce(b.meter_start_wh, n.meter_start_wh) as meter_start_wh,
+        coalesce(b.meter_stop_wh, n.meter_stop_wh) as meter_stop_wh,
+
+        -- Merge arrays using array_concat
+        array_distinct({{ array_concat('n.id_tags', 'b.id_tags') }}) as id_tags,
+        array_distinct({{ array_concat('n.id_tag_statuses', 'b.id_tag_statuses') }}) as id_tag_statuses,
+        array_distinct({{ array_concat('n.connector_ids', 'b.connector_ids') }}) as connector_ids
+
+    from transactions n
+    left join {{ this }} b
+        on n.charge_point_id = b.charge_point_id
+        and n.transaction_id = b.transaction_id
+        and b.transaction_stop_ts is null
+)
+{% endif %}
+
+select 
+    t.*,
+    tsn.error_codes,
+        
+    -- Calculate energy transferred from meterStart and meterStop values
+    cast(
+        case 
+            when t.meter_start_wh is not null and t.meter_stop_wh is not null
+            then (t.meter_stop_wh - t.meter_start_wh)/1000.0
+            else null
+        end as {{ dbt.type_numeric() }}
+    ) as energy_transferred_kwh,
+    case 
+        when t.connector_ids is not null and {{ array_size('t.connector_ids') }} > 0
+            then t.connector_ids[0]
+        else null
+    end as connector_id,
+
+    -- Count aggregations for testing
+    case 
+        when t.connector_ids is not null 
+            then {{ array_size('t.connector_ids') }}
+        else 0
+    end as _unique_connectors_count,
+
+    (select incremental_ts from incremental) as incremental_ts
+
+from 
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    combined_transactions t
+{% else %}
+    transactions t
+{% endif %}
+left join transaction_status_notifications tsn
+    on t.transaction_id = tsn.transaction_id
+    and t.charge_point_id = tsn.charge_point_id

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -118,3 +118,55 @@ models:
               - charge_point_id
               - connector_id
               - ingested_ts
+
+  - name: int_transactions
+    description: "Intermediate model that processes transaction-related OCPP events (StartTransaction, StopTransaction, RemoteStartTransaction, RemoteStopTransaction, MeterValues) and groups them by transaction ID. Each row represents a unique transaction with aggregated details."
+    columns:
+      - name: transaction_id
+        description: "Unique identifier for the transaction from OCPP StartTransaction/StopTransaction messages"
+        tests:
+          - not_null
+      - name: charge_point_id
+        description: "Identifier for the charge point"
+        tests:
+          - not_null
+      - name: connector_id
+        description: "Connector ID for this transaction"
+        tests:
+          - not_null
+      - name: ingested_ts
+        description: "Earliest timestamp when any OCPP event for this transaction was ingested"
+        tests:
+          - not_null
+      - name: transaction_start_ts
+        description: "Timestamp when the transaction started (from StartTransaction message)"
+        tests:
+          - not_null
+      - name: transaction_stop_ts
+        description: "Timestamp when the transaction stopped (from StopTransaction message)"
+      - name: transaction_stop_reason
+        description: "Reason for stopping the transaction (e.g., 'EVDisconnected', 'DeAuthorized', 'Local')"
+      - name: id_tags
+        description: "Array of RFID tags or user identifiers from Authorize/StartTransaction messages"
+      - name: id_tag_statuses
+        description: "Array of authorization statuses (e.g., 'Accepted', 'Blocked', 'Expired')"
+      - name: meter_start_wh
+        description: "Meter reading at transaction start (Wh)"
+      - name: meter_stop_wh
+        description: "Meter reading at transaction stop (Wh)"
+      - name: energy_transferred_kwh
+        description: "Total energy transferred in kWh (calculated from meter_stop_kw - meter_start_kw)"
+      - name: error_codes
+        description: "Array of error codes from StatusNotification events that occurred during the transaction"
+      - name: _unique_connectors_count
+        tests:
+          - accepted_values:
+              arguments:
+                values: [1]
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - connector_id
+              - ingested_ts


### PR DESCRIPTION
Building toward a model that represents individual charge attempts.
The original idea was to track connectors entering the Preparing state, but to account for cases like offline charging, the model will also allow standalone transactions to represent a charge attempt.

<img width="1168" height="373" alt="Screenshot 2025-10-09 at 10 23 55 PM" src="https://github.com/user-attachments/assets/15aeed07-6297-4f8f-b669-de10cb193621" />


This PR is 3/4 that adds an intermediate transactions model
- [x]  macros [13](https://github.com/appspace/kwwhat/pull/13) add macros  that works across different SQL platforms (Snowflake, PostgreSQL, BigQuery, etc.) — but only tested on Snowflake
- [x]  intermediate connector preparing model - captures what happens before and after a connector enters the Preparing state (auths, transactions, errors) [15](https://github.com/appspace/kwwhat/pull/15)
- [x]  intermediate transactions - an aggregate model of transactions
- [ ] attempts model as a join of preparing context to transactions, allowing for lone transactions [17](https://github.com/appspace/kwwhat/pull/17)

Example output:

`select * from dbt_dev1.int_transactions order by ingested_ts`

```
|   TRANSACTION_ID | CHARGE_POINT_ID    | CONNECTOR_IDS   | INGESTED_TS             | TRANSACTION_START_TS    | TRANSACTION_STOP_TS     | LAST_INGESTED_TS        | TRANSACTION_STOP_REASON   | ID_TAGS        | ID_TAG_STATUSES   |   METER_START_WH |   METER_STOP_WH | ERROR_CODES   |   ENERGY_TRANSFERRED_KWH | CONNECTOR_ID   |   _UNIQUE_CONNECTORS_COUNT | INCREMENTAL_TS          |
|-----------------:|:-------------------|:----------------|:------------------------|:------------------------|:------------------------|:------------------------|:--------------------------|:---------------|:------------------|-----------------:|----------------:|:--------------|-------------------------:|:---------------|---------------------------:|:------------------------|
|               82 | AL0012A1GPAV00181A | [ "1" ]         | 2025-07-21 16:39:06.545 | 2025-07-21 16:39:04.000 | 2025-07-21 22:03:14.000 | 2025-07-21 22:03:17.304 | EVDisconnected            | [ "SYS00TEM" ] | [ "Accepted" ]    |      2.21619e+06 |     2.26584e+06 | [ "NoError" ] |                   49.645 | "1"            |                          1 | 2025-07-21 22:36:03.526 |
|               26 | AL0012A1GPAV00181A | [ "1" ]         | 2025-07-22 00:19:29.329 | 2025-07-22 00:19:27.000 | 2025-07-22 00:21:37.000 | 2025-07-22 00:21:41.094 | EVDisconnected            | [ "SYS00TEM" ] | [ "Accepted" ]    |      2.26584e+06 |     2.26612e+06 | [ "NoError" ] |                    0.283 | "1"            |                          1 | 2025-07-31 16:14:07.404 |
|               92 | AL0012A1GPAV00181A | [ "1" ]         | 2025-07-22 20:06:21.549 | 2025-07-22 20:06:19.000 | 2025-07-22 20:06:28.000 | 2025-07-22 20:06:32.938 | Remote                    | [ "00dd58f3" ] | [ "Accepted" ]    |      2.26612e+06 |     2.26612e+06 | [ "NoError" ] |                    0     | "1"            |                          1 | 2025-07-31 16:14:07.404 |

…
```
