### PR TITLE
charge attempts / attempts

### DIFF
--- a/models/marts/charge_attempts.sql
+++ b/models/marts/charge_attempts.sql
@@ -1,0 +1,209 @@
+{{
+  config(
+    materialized='incremental',
+    unique_key=["charge_point_id", "connector_id", "ingested_ts"], 
+    incremental_strategy="merge",
+    cluster_by="ingested_ts"
+  )
+}}
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+            least(
+                {{ dbt.dateadd("month", 3, "from_timestamp") }},
+                (select max(incremental_ts) from {{ ref("int_connector_preparing") }}),
+                (select max(incremental_ts) from {{ ref("int_transactions") }})
+            ) as to_timestamp
+        from
+            (
+                select max(incremental_ts) as from_timestamp from {{ this }}
+            )
+    ),
+
+{% else %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+            least(
+                {{ dbt.dateadd("month", 3, "from_timestamp") }},
+                (select max(incremental_ts) from {{ ref("int_connector_preparing") }}),
+                (select max(incremental_ts) from {{ ref("int_transactions") }})
+            ) as to_timestamp
+        from
+            (
+                select cast( '{{ var("start_processing_date") }}' as {{ dbt.type_timestamp() }}) as from_timestamp
+            )
+    ),
+{% endif %}
+
+charge_attempts as (
+    select
+        charge_point_id,
+        connector_id,
+        unique_id as charge_attempt_unique_id,
+        ingested_ts as charge_attempt_ingested_ts,
+        previous_ingested_ts,
+        next_ingested_ts,
+        previous_status,
+        status,
+        next_status,
+        id_tags,
+        id_tag_statuses,
+        transaction_id,
+        error_codes,
+        incremental_ts
+    from {{ ref('int_connector_preparing') }}
+    where ingested_ts > (select from_timestamp from incremental_date_range)
+        and ingested_ts <= (select to_timestamp from incremental_date_range)
+),
+
+transactions as (
+    select
+        charge_point_id,
+        connector_id,
+        transaction_id,
+        ingested_ts as transaction_ingested_ts,
+        transaction_start_ts,
+        transaction_stop_ts,
+        transaction_stop_reason,
+        id_tags,
+        id_tag_statuses,
+        meter_start_wh,
+        meter_stop_wh,
+        energy_transferred_kwh,
+        error_codes,
+        incremental_ts as transaction_incremental_ts
+    from {{ ref('int_transactions') }}
+    where ingested_ts > (select from_timestamp from incremental_date_range)
+        and ingested_ts <= (select to_timestamp from incremental_date_range)
+),
+
+incremental as (
+    select
+        greatest(
+            coalesce(
+                (select max(charge_attempt_ingested_ts) from charge_attempts), 
+                '1900-01-01'::timestamp
+            ),
+            coalesce(
+                (select max(transaction_ingested_ts) from transactions), 
+                '1900-01-01'::timestamp
+            )
+        ) as incremental_ts
+),
+
+attempts_and_transactions as (
+    select
+        -- Charge attempt identifiers
+        coalesce(att.charge_point_id, t.charge_point_id) as charge_point_id,
+        coalesce(att.connector_id, t.connector_id) as connector_id,
+        coalesce(att.charge_attempt_ingested_ts, t.transaction_ingested_ts) as ingested_ts,
+        
+        -- Charge attempt details
+        att.charge_attempt_ingested_ts,
+        att.charge_attempt_unique_id,
+        att.previous_status,
+        att.status,
+        att.next_status,
+        array_distinct({{ array_concat('att.id_tags', 't.id_tags') }}) as id_tags,
+        array_distinct({{ array_concat('att.id_tag_statuses', 't.id_tag_statuses') }}) as id_tag_statuses,
+
+        -- Transaction details
+        coalesce(att.transaction_id, t.transaction_id) as transaction_id,
+        t.transaction_start_ts,
+        t.transaction_stop_ts,
+        t.transaction_ingested_ts,
+        t.transaction_stop_reason,
+        t.meter_start_wh,
+        t.meter_stop_wh,
+        t.energy_transferred_kwh,
+        
+        -- Error details - concatenate error codes from both sources
+        array_distinct({{ array_concat('att.error_codes', 't.error_codes') }}) as error_codes
+        
+    from charge_attempts att
+    full outer join transactions t
+        on att.charge_point_id = t.charge_point_id
+        and att.connector_id = t.connector_id
+        and att.transaction_id = t.transaction_id
+        and t.transaction_ingested_ts > {{ dbt.dateadd("second", -var("authorize_time_threshold_seconds"), 'coalesce(att.previous_ingested_ts, att.charge_attempt_ingested_ts)') }}
+        and t.transaction_ingested_ts <= {{ dbt.dateadd("second", var("authorize_time_threshold_seconds"), 'coalesce(att.next_ingested_ts, att.charge_attempt_ingested_ts)') }}
+        
+)
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+   ,
+   
+    -- Read previously stored charge attempts within buffer window
+    charge_attempts_buffer as (
+        select
+            charge_point_id,
+            connector_id,
+            ingested_ts,
+            charge_attempt_unique_id,
+            charge_attempt_ingested_ts,
+            previous_status,
+            status,
+            next_status,
+            id_tags,
+            id_tag_statuses,
+            transaction_id,
+            transaction_start_ts,
+            transaction_stop_ts,
+            transaction_ingested_ts,
+            transaction_stop_reason,
+            meter_start_wh,
+            meter_stop_wh,
+            energy_transferred_kwh,
+            error_codes,
+            incremental_ts
+        from {{ this }}
+        where ingested_ts > (select buffer_from_timestamp from incremental_date_range)
+            and ingested_ts <= (select from_timestamp from incremental_date_range)
+    ),
+
+    merged_attempts_and_transactions as (
+        select
+            n.charge_point_id,
+            n.connector_id,
+            coalesce(b.ingested_ts, n.ingested_ts) as ingested_ts,
+
+            coalesce(n.charge_attempt_unique_id, b.charge_attempt_unique_id) as charge_attempt_unique_id,
+            coalesce(n.charge_attempt_ingested_ts, b.charge_attempt_ingested_ts) as charge_attempt_ingested_ts,
+            -- once set, ingested_ts should not be changed as it is a unique identifier (used for clustering/partitioning/merging)
+            coalesce(n.previous_status, b.previous_status) as previous_status,
+            coalesce(n.status, b.status) as status,
+            coalesce(n.next_status, b.next_status) as next_status,
+            coalesce(n.transaction_id, b.transaction_id) as transaction_id,
+            coalesce(n.transaction_start_ts, b.transaction_start_ts) as transaction_start_ts,
+            coalesce(n.transaction_stop_ts, b.transaction_stop_ts) as transaction_stop_ts,
+            coalesce(n.transaction_ingested_ts, b.transaction_ingested_ts) as transaction_ingested_ts,
+            coalesce(n.transaction_stop_reason, b.transaction_stop_reason) as transaction_stop_reason,
+            coalesce(n.meter_start_wh, b.meter_start_wh) as meter_start_wh,
+            coalesce(n.meter_stop_wh, b.meter_stop_wh) as meter_stop_wh,
+            coalesce(n.energy_transferred_kwh, b.energy_transferred_kwh) as energy_transferred_kwh,
+
+            -- Merge arrays using array_concat
+            array_distinct({{ array_concat('n.id_tags', 'b.id_tags') }}) as id_tags,
+            array_distinct({{ array_concat('n.id_tag_statuses', 'b.id_tag_statuses') }}) as id_tag_statuses,
+            array_distinct({{ array_concat('n.error_codes', 'b.error_codes') }}) as error_codes
+
+        from attempts_and_transactions n
+        left join charge_attempts_buffer b on n.charge_point_id = b.charge_point_id
+            and n.connector_id = b.connector_id
+            and n.transaction_id is not null and b.transaction_id is not null and n.transaction_id = b.transaction_id
+    )
+{% endif %}
+
+select *,
+    (select incremental_ts from incremental) as incremental_ts
+from 
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    merged_attempts_and_transactions
+{% else %}
+    attempts_and_transactions
+{% endif %}

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -1,0 +1,69 @@
+version: 2
+
+models:
+  - name: charge_attempts
+    description: "Incremental marts model that combines charge attempts and transactions data using outer join. Provides comprehensive view of charge attempts with associated transaction details where available."
+    columns:
+      - name: charge_point_id
+        description: "Identifier for the charge point"
+        tests:
+          - not_null
+      - name: connector_id
+        description: "Identifier for the charging connector"
+        tests:
+          - not_null
+      - name: charge_attempt_unique_id
+        description: "Unique identifier for the charge attempt from status change"
+      - name: charge_attempt_ingested_ts
+        description: "Timestamp when the charge attempt was ingested"
+      - name: confirmation_ingested_ts
+        description: "Timestamp when the status change confirmation was received"
+      - name: previous_status
+        description: "Status before changing to 'Preparing'"
+      - name: status
+        description: "Current status (should be 'Preparing')"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Preparing']
+      - name: next_status
+        description: "Next status after 'Preparing' (e.g., 'Charging', 'Available', 'Faulted')"
+      - name: id_tags
+        description: "Array of RFID tags or user identifiers from charge attempt events"
+      - name: id_tag_statuses
+        description: "Array of authorization statuses from charge attempt events"
+      - name: transaction_id
+        description: "Transaction ID (from charge attempt or transaction data)"
+        tests:
+          - unique
+      - name: transaction_ingested_ts
+        description: "Earliest timestamp when any OCPP event for this transaction was ingested"
+      - name: transaction_start_ts
+        description: "Timestamp when the transaction started"
+      - name: transaction_stop_ts
+        description: "Timestamp when the transaction stopped"
+      - name: transaction_stop_reason
+        description: "Reason for stopping the transaction"
+      - name: transaction_id_tags
+        description: "Array of RFID tags or user identifiers from transaction events"
+      - name: transaction_id_tag_statuses
+        description: "Array of authorization statuses from transaction events"
+      - name: meter_start_wh
+        description: "Meter reading at transaction start (Wh)"
+      - name: meter_stop_wh
+        description: "Meter reading at transaction stop (Wh)"
+      - name: energy_transferred_kwh
+        description: "Total energy transferred in kWh"
+      - name: error_codes
+        description: "Array of error codes from both charge attempt events and StatusNotification events during the transaction"
+      - name: incremental_ts
+        description: "Latest incremental processing timestamp from both source models for incremental processing tracking"
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - connector_id
+              - ingested_ts


### PR DESCRIPTION
Building toward a model that represents individual charge attempts.
The original idea was to track connectors entering the Preparing state, but to account for cases like offline charging, the model will also allow standalone transactions to represent a charge attempt.

<img width="1168" height="373" alt="Screenshot 2025-10-09 at 10 23 55 PM" src="https://github.com/user-attachments/assets/15aeed07-6297-4f8f-b669-de10cb193621" />


This PR is 4/5 that adds a final attempts model
- [x]  macros [13](https://github.com/appspace/kwwhat/pull/13) add macros  that works across different SQL platforms (Snowflake, PostgreSQL, BigQuery, etc.) — but only tested on Snowflake
- [x]  intermediate connector preparing model - captures what happens before and after a connector enters the Preparing state (auths, transactions, errors) [15](https://github.com/appspace/kwwhat/pull/15)
- [x]  intermediate transactions - an aggregate model of transactions [16](https://github.com/appspace/kwwhat/pull/16)
- [x]  attempts model as a join of preparing context to transactions, allowing for lone transactions [17](https://github.com/appspace/kwwhat/pull/17)
- [ ]  cleanup refactoring [18](https://github.com/appspace/kwwhat/pull/18)

Example output:


`select * from dbt_dev1.charge_attempts order by ingested_ts`

```
| CHARGE_POINT_ID    | CONNECTOR_ID | INGESTED_TS             | CHARGE_ATTEMPT_INGESTED_TS   | CHARGE_ATTEMPT_UNIQUE_ID | PREVIOUS_STATUS | STATUS    | NEXT_STATUS | ID_TAGS                               | ID_TAG_STATUSES   | TRANSACTION_ID | TRANSACTION_START_TS    | TRANSACTION_STOP_TS     | TRANSACTION_INGESTED_TS   | TRANSACTION_STOP_REASON | METER_START_WH | METER_STOP_WH  | ENERGY_TRANSFERRED_KWH | ERROR_CODES   | INCREMENTAL_TS          |
|:-------------------|-------------:|:------------------------|:-----------------------------|:-------------------------|:----------------|:----------|:------------|:--------------------------------------|:------------------|:---------------|:------------------------|:------------------------|:--------------------------|:------------------------|---------------:|---------------:|-----------------------:|:--------------|:------------------------|
| AL0012A1GPAV00181A | 1            | 2025-07-21 16:37:01.219 | 2025-07-21 16:37:01.219      | 202507211                | Available       | Preparing | Charging    | ["SYS00TEM"]                          | ["Accepted"]      | 82             | 2025-07-21 16:39:04.000 | 2025-07-21 22:03:14.000 | 2025-07-21 16:39:06.545   | EVDisconnected          | 2.21619e+06    | 2.26584e+06    | 49.645                 | ["NoError"]   | 2025-07-29 18:09:37.571 |
| AL0012A1GPAV00181A | 1            | 2025-07-22 00:17:42.701 | 2025-07-22 00:17:42.701      | 202507212                | Available       | Preparing | Charging    | ["SYS00TEM"]                          | ["Accepted"]      | 26             | 2025-07-22 00:19:27.000 | 2025-07-22 00:21:37.000 | 2025-07-22 00:19:29.329   | EVDisconnected          | 2.26584e+06    | 2.26612e+06    | 0.283                  | ["NoError"]   | 2025-07-29 18:09:37.571 |
| AL0012A1GPAV00181A | 1            | 2025-07-22 20:08:02.452 | nan                          | nan                      | nan             | nan       | nan         | ["94a13f95", "SYS00TEM", "00dd58f3”]  | ["Accepted"]      | 66             | 2025-07-22 20:07:27.000 | 2025-07-23 17:44:00.000 | 2025-07-22 20:08:02.452   | EVDisconnected          | 2.26612e+06    | 2.27059e+06    | 4.468                  | ["NoError"]   | 2025-07-29 18:09:37.571 |
| AL0012A1GPAV00181A | 1            | 2025-07-24 16:46:08.815 | 2025-07-24 16:46:08.815      | 202507213                | Available       | Preparing | Available   | []                                    | []                | nan            | nan                     | nan                     | nan                       | nan                     | nan            | nan            | nan                    | ["NoError"]   | 2025-07-29 18:09:37.571 |

...
```