### PR TITLE
charger-attempts / incrememntality refactoring

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -48,10 +48,14 @@ vars:
   raw_schema: "SEED"
   ocpp_logs_identifier: "ocpp_1_6_synthetic_logs_1d"
   start_processing_date: "2025-08-18"
+  incremental_window:
+    unit: "month"
+    length: 3
+
   authorize_time_threshold_seconds: 300
   transaction_message_retry_interval: 45
   message_type_ids:
     CALL: "2"
     CALLRESULT: "3"
     CALLERROR: "4"
-
+  

--- a/models/intermediate/int_connector_preparing.sql
+++ b/models/intermediate/int_connector_preparing.sql
@@ -15,7 +15,7 @@
             from_timestamp,
             {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
             least(
-                {{ dbt.dateadd("month", 3, "from_timestamp") }},
+                {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }},
                 (select max(incremental_ts) from {{ ref("int_status_changes") }}),
                 (select max(ingested_timestamp) from {{ ref("stg_ocpp_logs") }})
             ) as to_timestamp
@@ -31,7 +31,7 @@
             from_timestamp,
             {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
             least(
-                {{ dbt.dateadd("month", 3, "from_timestamp") }},
+                {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }},
                 (select max(incremental_ts) from {{ ref("int_status_changes") }}),
                 (select max(ingested_timestamp) from {{ ref("stg_ocpp_logs") }})
             ) as to_timestamp

--- a/models/intermediate/int_transactions.sql
+++ b/models/intermediate/int_transactions.sql
@@ -13,7 +13,7 @@
     with incremental_date_range as (
         select
             from_timestamp,
-            {{ dbt.dateadd("month", 3, "from_timestamp") }} as to_timestamp
+            {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }} as to_timestamp
         from
             (
                 select (select max(incremental_ts) from {{ this }}) as from_timestamp
@@ -24,7 +24,7 @@
     with incremental_date_range as (
         select
             from_timestamp,
-            {{ dbt.dateadd("month", 3, "from_timestamp") }} as to_timestamp
+            {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }} as to_timestamp
         from
             (
                 select cast( '{{ var("start_processing_date") }}' as {{ dbt.type_timestamp() }}) as from_timestamp


### PR DESCRIPTION
Building toward a model that represents individual charge attempts.
The original idea was to track connectors entering the Preparing state, but to account for cases like offline charging, the model will also allow standalone transactions to represent a charge attempt.

<img width="1168" height="373" alt="Screenshot 2025-10-09 at 10 23 55 PM" src="https://github.com/user-attachments/assets/15aeed07-6297-4f8f-b669-de10cb193621" />


This PR is 5/5 is moving things around, reuses code, adds variables in config.
- [x]  macros [13](https://github.com/appspace/kwwhat/pull/13) add macros  that works across different SQL platforms (Snowflake, PostgreSQL, BigQuery, etc.) — but only tested on Snowflake
- [x]  intermediate connector preparing model - captures what happens before and after a connector enters the Preparing state (auths, transactions, errors) [15](https://github.com/appspace/kwwhat/pull/15)
- [x]  intermediate transactions - an aggregate model of transactions [16](https://github.com/appspace/kwwhat/pull/16)
- [x]  attempts model as a join of preparing context to transactions, allowing for lone transactions [17](https://github.com/appspace/kwwhat/pull/17)
- [x]  cleanup refactoring [18](https://github.com/appspace/kwwhat/pull/18)