### PR TITLE
Interval data

### DIFF
--- a/macros/json_array_unnest.sql
+++ b/macros/json_array_unnest.sql
@@ -1,0 +1,27 @@
+{% macro json_array_unnest(json_column) %}
+    {#
+      Cross-warehouse compatible unnest for JSON arrays
+      
+      Args:
+        json_column: The JSON array column to unnest
+      
+      Example:
+        cross join {{ json_array_unnest('meter_values') }}
+    #}
+    {% if target.type == 'snowflake' %}
+        cross join lateral flatten(input => parse_json({{ json_column }}))
+    {% elif target.type == 'bigquery' %}
+        cross join unnest(json_extract_array({{ json_column }}))
+    {% elif target.type == 'duckdb' %}
+        cross join unnest(json_extract({{ json_column }}, '$'))
+    {% elif target.type in ['postgres', 'redshift'] %}
+        cross join unnest({{ json_column }})
+    {% elif target.type in ['spark', 'databricks'] %}
+        cross join lateral explode({{ json_column }})
+    {% elif target.type in ['trino', 'presto', 'athena'] %}
+        cross join unnest(json_extract_array({{ json_column }}, '$'))
+    {% else %}
+        -- Fallback for other warehouses - may need adjustment
+        cross join unnest({{ json_column }})
+    {% endif %}
+{% endmacro %}

--- a/models/marts/interval_data.sql
+++ b/models/marts/interval_data.sql
@@ -1,0 +1,261 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["charge_point_id", "transaction_id", "ingested_ts", "connector_id", "measurand", "unit", "phase"],
+        incremental_strategy="merge",
+        cluster_by="ingested_ts"
+    )
+}}
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    with incremental_date_range as (
+            select
+                from_timestamp,
+                {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+                least(
+                    {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }},
+                    (select max(incremental_ts) from {{ ref("meter_values") }})
+                ) as to_timestamp
+        from
+            (
+                select (select max(incremental_ts) from {{ this }}) as from_timestamp
+            )
+        ),
+
+{% else %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+            least(
+                {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }},
+                (select max(incremental_ts) from {{ ref("meter_values") }})
+            ) as to_timestamp
+        from
+            (
+                    select
+                    greatest(
+                        cast( '{{ var("start_processing_date") }}' as {{ dbt.type_timestamp() }}),
+                        (select min(ingested_timestamp) from {{ ref("stg_ocpp_logs") }})
+                    ) as from_timestamp
+                )
+        ),
+{% endif %}
+
+    ocpp_logs as (
+        select
+            charge_point_id,
+            action,
+            ingested_timestamp as ingested_ts,
+            message_type_id,
+            payload
+        from {{ ref("stg_ocpp_logs") }}
+        where ingested_timestamp > (select from_timestamp from incremental_date_range)
+            and ingested_timestamp <= (select to_timestamp from incremental_date_range)
+    ),
+
+    meter_values as (
+        select
+            charge_point_id,
+            transaction_id,
+            ingested_ts,
+            connector_id,
+            measurand,
+            unit,
+            phase,
+            {{ dbt.dateadd("minute", '-(minute(first_measurement_ts) % 15)', dbt.date_trunc("minute", 'first_measurement_ts')) }} as first_interval,
+            {{ dbt.dateadd("minute", '-(minute(last_measurement_ts) % 15)', dbt.date_trunc("minute", 'last_measurement_ts')) }} as last_interval,
+            first_measurement_ts,
+            last_measurement_ts
+        from {{ ref("meter_values") }}
+    ),
+
+    incremental as (
+        select
+            max(ingested_ts) as incremental_ts
+        from ocpp_logs
+    ),
+
+    meter_value_logs as (
+        select
+            ingested_ts,
+            charge_point_id,
+            payload,
+            {{ payload_extract_connector_id('action', 'payload') }} as connector_id,
+            {{ payload_extract_transaction_id('action', 'payload', 'null') }} as transaction_id,
+            {{ payload_extract_meter_values('action', 'payload') }} as meter_values
+        from ocpp_logs
+        where action = 'MeterValues'
+            and message_type_id = {{ var("message_type_ids").CALL }}
+    ),
+
+    meter_value_records as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            -- Extract timestamp from the meter value object
+            cast({{ fivetran_utils.json_extract(string="mv.value", string_path="timestamp") }} as {{ dbt.type_timestamp() }}) as meter_timestamp,
+            -- Keep the full meter value object for now
+            {{ fivetran_utils.json_extract(string="mv.value", string_path="sampledValue") }} as sample_values
+        from meter_value_logs
+        {{ json_array_unnest('meter_values') }} as mv
+        where meter_values is not null
+            and mv.value is not null
+    ),
+
+    sample_values as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            meter_timestamp,
+            mv.value as sample_values
+        from meter_value_records
+        {{ json_array_unnest('sample_values') }} as mv
+    ),
+
+    measurements as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            meter_timestamp,
+            {{ dbt.dateadd("minute", '-(minute(meter_timestamp) % 15)', dbt.date_trunc("minute", 'meter_timestamp')) }} as meter_15min_interval_start,
+            {{ fivetran_utils.pivot_json_extract(string="sample_values", list_of_properties=["measurand", "value", "unit", "phase"]) }}
+        from sample_values
+    ),
+
+    measurements_with_context as (
+        select
+            m.charge_point_id,
+            m.connector_id,
+            m.transaction_id,
+            mv.ingested_ts,
+            mv.first_interval,
+            mv.last_interval,
+            mv.first_measurement_ts,
+            mv.last_measurement_ts,
+            m.meter_timestamp,
+            m.meter_15min_interval_start,
+            m.measurand,
+            m.unit,
+            m.phase,
+            m.value
+        from measurements m
+        left join meter_values mv on m.charge_point_id = mv.charge_point_id
+            and m.connector_id = mv.connector_id
+            and m.transaction_id = mv.transaction_id
+            and m.measurand = mv.measurand
+            and m.unit = mv.unit
+            and ((m.phase is null and mv.phase is null) or m.phase = mv.phase)
+            and m.meter_timestamp >= mv.first_measurement_ts
+            and m.meter_timestamp <= mv.last_measurement_ts
+    ),
+
+    intervals_15min as (
+            select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            -- Rebates reporting requires 15-minute interval data (e.g., 10:00, 10:15, 10:30).
+            -- The first and last intervals correspond to when energy transfer starts and stops.
+            case 
+                when meter_15min_interval_start = first_interval then first_measurement_ts
+                else meter_15min_interval_start 
+            end as meter_15min_interval_start,
+            case 
+                when meter_15min_interval_start = last_interval then last_measurement_ts 
+                else {{ dbt.dateadd("minute", 15, "meter_15min_interval_start") }}
+            end as meter_15min_interval_stop,            
+            measurand,
+            unit,
+            phase,
+            value
+        from measurements_with_context
+        where value is not null and value != ''
+    ),
+
+    agg_15min as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            meter_15min_interval_start,
+            meter_15min_interval_stop,
+            measurand,
+            unit,
+            phase,
+            
+            -- interval avg value
+            avg(cast(value as {{ dbt.type_float() }})) as avg_value,
+            count(*) as _count
+        from intervals_15min
+        group by
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            meter_15min_interval_start,
+            meter_15min_interval_stop,
+            measurand,
+            unit,
+            phase
+    ),
+
+    final as (
+    {% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+
+        select
+            n.charge_point_id,
+            n.transaction_id,
+            n.ingested_ts,
+            n.connector_id,
+            n.measurand,
+            n.unit,
+            n.phase,
+            n.meter_15min_interval_start,
+            n.meter_15min_interval_stop,
+            case 
+                when b.avg_value is null then n.avg_value
+                else (n.avg_value*n._count + b.avg_value*b._count) / (n._count + b._count) 
+            end as avg_value,
+            case 
+                when b._count is null then n._count
+                else (n._count + b._count)
+            end as _count
+        from agg_15min n
+        left join {{ this }} b
+            on n.charge_point_id = b.charge_point_id
+            and n.connector_id = b.connector_id
+            and n.transaction_id = b.transaction_id
+            and n.ingested_ts = b.ingested_ts
+            and n.measurand = b.measurand
+            and n.unit = b.unit
+            and n.phase = b.phase
+            and n.meter_15min_interval_start = b.meter_15min_interval_start
+
+    {% else %}
+
+        select
+            *
+        from agg_15min
+    {% endif %}
+    )
+
+    select
+        charge_point_id,
+        transaction_id,
+        ingested_ts,
+        connector_id,
+        measurand,
+        unit,
+        phase,
+        meter_15min_interval_start,
+        meter_15min_interval_stop,
+        avg_value,
+        _count,
+        (select incremental_ts from incremental) as incremental_ts
+    from final

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -67,3 +67,126 @@ models:
               - charge_point_id
               - connector_id
               - ingested_ts
+
+  - name: meter_values
+    description: "Transaction-level aggregated meter values. Provides min, max, and average values for each measurand aggregated across the entire transaction. Use for transaction-level analysis."
+    columns:
+      - name: charge_point_id
+        description: "Unique identifier for the charging point"
+        tests:
+          - not_null
+      - name: transaction_id
+        description: "Unique identifier for the charging transaction"
+        tests:
+          - not_null
+      - name: connector_id
+        description: "Unique identifier for the connector within the charging point"
+        tests:
+          - not_null
+      - name: ingested_ts
+        description: "Timestamp when transaction was ingested into the system"
+        tests:
+          - not_null
+      - name: measurand
+        description: "Type of measurement (e.g., Energy.Active.Import.Register, Voltage, Current.Import)"
+        tests:
+          - not_null
+      - name: unit
+        description: "Unit of measurement (e.g., Wh, V, A, W)"
+        tests:
+          - not_null
+      - name: phase
+        description: "Electrical phase (e.g., L1, L2, L3) or null for single-phase measurements"
+      - name: first_measurement_ts
+        description: "Meter timestamp of the first measurement for the transaction"
+        tests:
+          - not_null
+      - name: last_measurement_ts
+        description: "Meter timestamp of the last measurement for the transaction"
+        tests:
+          - not_null
+      - name: min_value
+        description: "Minimum value recorded for the transaction"
+        tests:
+          - not_null
+      - name: max_value
+        description: "Maximum value recorded for the transaction"
+        tests:
+          - not_null
+      - name: avg_value
+        description: "Average value for the transaction"
+        tests:
+          - not_null
+      - name: _count
+        description: "Total number of measurements for the transaction"
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - connector_id
+              - transaction_id
+              - ingested_ts
+              - measurand
+              - unit
+              - phase
+
+  - name: interval_data
+    description: "15-minute interval meter values. Provides average values for each measurand within each 15-minute interval. Use for rebates reporting and time-series analysis."
+    columns:
+      - name: charge_point_id
+        description: "Unique identifier for the charging point"
+        tests:
+          - not_null
+      - name: transaction_id
+        description: "Unique identifier for the charging transaction"
+        tests:
+          - not_null
+      - name: connector_id
+        description: "Unique identifier for the connector within the charging point"
+        tests:
+          - not_null
+      - name: ingested_ts
+        description: "Timestamp when transaction was ingested into the system"
+        tests:
+          - not_null
+      - name: measurand
+        description: "Type of measurement (e.g., Energy.Active.Import.Register, Voltage, Current.Import)"
+        tests:
+          - not_null
+      - name: unit
+        description: "Unit of measurement (e.g., Wh, V, A, W)"
+        tests:
+          - not_null
+      - name: phase
+        description: "Electrical phase (e.g., L1, L2, L3) or null for single-phase measurements"
+      - name: meter_15min_interval_start
+        description: "Start timestamp of the 15-minute interval. For the first interval, this is the actual first measurement time; for subsequent intervals, it's the 15-minute boundary."
+        tests:
+          - not_null
+      - name: meter_15min_interval_stop
+        description: "End timestamp of the 15-minute interval. For the last interval, this is the actual last measurement time; for other intervals, it's the next 15-minute boundary."
+        tests:
+          - not_null
+      - name: avg_value
+        description: "Average value for the measurand within this 15-minute interval"
+        tests:
+          - not_null
+      - name: _count
+        description: "Number of measurements within this 15-minute interval"
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - connector_id
+              - transaction_id
+              - ingested_ts
+              - measurand
+              - unit
+              - phase
+              - meter_15min_interval_start

--- a/models/marts/meter_values.sql
+++ b/models/marts/meter_values.sql
@@ -1,0 +1,248 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["charge_point_id", "transaction_id", "ingested_ts", "connector_id", "measurand", "unit", "phase"],
+        incremental_strategy="merge",
+        cluster_by="ingested_ts"
+    )
+}}
+
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+    with incremental_date_range as (
+            select
+                from_timestamp,
+                {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+                {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }} as to_timestamp
+        from
+            (
+                select (select max(incremental_ts) from {{ this }}) as from_timestamp
+            )
+        ),
+
+{% else %}
+    with incremental_date_range as (
+        select
+            from_timestamp,
+            {{ dbt.dateadd("minute", -30, "from_timestamp") }} as buffer_from_timestamp,
+            {{ dbt.dateadd(var("incremental_window").unit, var("incremental_window").length, "from_timestamp") }} as to_timestamp
+        from
+            (
+                    select
+                    greatest(
+                        cast( '{{ var("start_processing_date") }}' as {{ dbt.type_timestamp() }}),
+                        (select min(ingested_timestamp) from {{ ref("stg_ocpp_logs") }})
+                    ) as from_timestamp
+                )
+        ),
+{% endif %}
+
+    ocpp_logs as (
+        select
+            charge_point_id,
+            action,
+            ingested_timestamp as ingested_ts,
+            message_type_id,
+            payload
+        from {{ ref("stg_ocpp_logs") }}
+        where ingested_timestamp > (select from_timestamp from incremental_date_range)
+            and ingested_timestamp <= (select to_timestamp from incremental_date_range)
+    ),
+
+    transactions as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            last_ingested_ts
+        from {{ ref("int_transactions") }}
+    ),
+
+    incremental as (
+        select
+            max(ingested_ts) as incremental_ts
+        from ocpp_logs
+    ),
+
+    -- Example:
+    -- [
+    --     {
+    --         sampledValue:
+    --         [
+    --             {measurand:Energy.Active.Import.Register,unit:Wh,value:2300270.0},
+    --             {measurand:Voltage,phase:L1,unit:V,value:211.6},
+    --             {measurand:Current.Import,phase:L1,unit:A,value:0.41},
+    --             {measurand:Power.Offered,unit:W,value:1},
+    --             {measurand:Power.Active.Import,unit:W,value:1}
+    --         ],
+    --         timestamp:2025-10-03T18:02:01.700Z
+    --     }
+    -- ]
+
+    meter_value_logs as (
+        select
+            ingested_ts,
+            charge_point_id,
+            payload,
+            {{ payload_extract_connector_id('action', 'payload') }} as connector_id,
+            {{ payload_extract_transaction_id('action', 'payload', 'null') }} as transaction_id,
+            {{ payload_extract_meter_values('action', 'payload') }} as meter_values
+        from ocpp_logs
+        where action = 'MeterValues'
+            and message_type_id = {{ var("message_type_ids").CALL }}
+    ),
+
+    meter_value_messages as (
+        select
+            l.charge_point_id,
+            t.ingested_ts,
+            l.connector_id,
+            l.transaction_id,
+            l.meter_values
+        from meter_value_logs l
+        left join transactions t on l.charge_point_id = t.charge_point_id
+            and l.connector_id = t.connector_id
+            and l.transaction_id = t.transaction_id
+            and l.ingested_ts >= t.ingested_ts
+            and l.ingested_ts <= t.last_ingested_ts
+    ),
+
+    meter_values as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            -- Extract timestamp from the meter value object
+            cast({{ fivetran_utils.json_extract(string="mv.value", string_path="timestamp") }} as {{ dbt.type_timestamp() }}) as meter_timestamp,
+            -- Keep the full meter value object for now
+            {{ fivetran_utils.json_extract(string="mv.value", string_path="sampledValue") }} as sample_values
+        from meter_value_messages
+        {{ json_array_unnest('meter_values') }} as mv
+        where meter_values is not null
+            and mv.value is not null
+    ),
+
+    sample_values as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            meter_timestamp,
+            mv.value as sample_values
+        from meter_values
+        {{ json_array_unnest('sample_values') }} as mv
+    ),
+
+    measurements as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            meter_timestamp,
+            {{ dbt.dateadd("minute", '-(minute(meter_timestamp) % 15)', dbt.date_trunc("minute", 'meter_timestamp')) }} as meter_15min_interval_start,
+            {{ fivetran_utils.pivot_json_extract(string="sample_values", list_of_properties=["measurand", "value", "unit", "phase"]) }}
+        from sample_values
+    ),
+
+    agg_transaction as (
+        select
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            measurand,
+            unit,
+            phase,
+            -- Keep the first and last timestamps for context
+            min(meter_timestamp) as first_measurement_ts,
+            max(meter_timestamp) as last_measurement_ts,
+            -- Aggregated values
+            min(cast(value as {{ dbt.type_float() }})) as min_value,
+            max(cast(value as {{ dbt.type_float() }})) as max_value,
+            avg(cast(value as {{ dbt.type_float() }})) as avg_value,
+
+            count(*) as _count
+        from measurements
+        where value is not null and value != ''
+        group by
+            charge_point_id,
+            transaction_id,
+            connector_id,
+            ingested_ts,
+            measurand,
+            unit,
+            phase
+    ),
+
+    final as (
+    {% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+
+        select
+            n.charge_point_id,
+            n.transaction_id,
+            n.ingested_ts,
+            n.connector_id,
+            n.measurand,
+            n.unit,
+            n.phase,
+            case 
+                when b.first_measurement_ts is null then n.first_measurement_ts
+                else least(n.first_measurement_ts, b.first_measurement_ts) 
+            end as first_measurement_ts,
+            case 
+                when b.last_measurement_ts is null then n.last_measurement_ts
+                else greatest(n.last_measurement_ts, b.last_measurement_ts) 
+            end as last_measurement_ts,
+            case 
+                when b.min_value is null then n.min_value
+                else least(n.min_value, b.min_value) 
+            end as min_value,
+            case 
+                when b.max_value is null then n.max_value
+                else greatest(n.max_value, b.max_value) 
+            end as max_value,
+            case 
+                when b.avg_value is null then n.avg_value
+                else (n.avg_value*n._count + b.avg_value*b._count) / (n._count + b._count) 
+            end as avg_value,
+            case
+                when b._count is null then n._count
+                else n._count + b._count 
+            end as _count
+        from agg_transaction n
+        left join {{ this }} b
+            on n.charge_point_id = b.charge_point_id
+            and n.connector_id = b.connector_id
+            and n.transaction_id = b.transaction_id
+            and n.ingested_ts = b.ingested_ts
+            and n.measurand = b.measurand
+            and n.unit = b.unit
+            and n.phase = b.phase
+
+    {% else %}
+
+        select
+            *
+        from agg_transaction
+    {% endif %}
+    )
+
+    select
+        charge_point_id,
+        transaction_id,
+        ingested_ts,
+        connector_id,
+        measurand,
+        unit,
+        phase,
+        first_measurement_ts,
+        last_measurement_ts,
+        min_value,
+        max_value,
+        avg_value,
+        _count,
+        (select incremental_ts from incremental) as incremental_ts
+    from final


### PR DESCRIPTION
Meter Values aggregated as Min, Max, Avg + 15 min intervals [for every measurand in the payload]
<img width="1030" height="308" alt="Screenshot 2025-11-01 at 4 00 09 PM" src="https://github.com/user-attachments/assets/131a590b-3ad7-4995-afe8-bce7aec6a2ac" />



Example:

```
select *
from dbt_dev1.meter_values
where transaction_id = '1014';
```


```
| CHARGE_POINT_ID | TRANSACTION_ID | INGESTED_TS             | CONNECTOR_ID | MEASURAND                     | UNIT | PHASE | FIRST_MEASUREMENT_TS    | LAST_MEASUREMENT_TS     |  MIN_VALUE |  MAX_VALUE |  AVG_VALUE | _COUNT | INCREMENTAL_TS          |
| :-------------- | -------------: | :---------------------- | -----------: | :---------------------------- | :--- | :---- | :---------------------- | :---------------------- | ---------: | ---------: | ---------: | -----: | :---------------------- |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Power.Active.Import           | W    | nan   | 2025-10-06 14:58:01.700 | 2025-10-06 15:00:01.700 |          1 |          1 |          1 |      3 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Energy.Active.Import.Register | Wh   | L1    | 2025-10-06 15:01:01.700 | 2025-10-06 15:01:01.700 |  2.302e+06 |  2.302e+06 |  2.302e+06 |      1 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Energy.Active.Import.Register | Wh   | nan   | 2025-10-06 14:58:01.700 | 2025-10-06 15:00:01.700 | 2.3004e+06 | 2.3004e+06 | 2.3004e+06 |      3 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Voltage                       | V    | L1    | 2025-10-06 14:58:01.700 | 2025-10-06 15:00:01.700 |      211.6 |      211.6 |      211.6 |      3 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Power.Offered                 | W    | nan   | 2025-10-06 14:58:01.700 | 2025-10-06 15:00:01.700 |          1 |          1 |          1 |      3 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Current.Import                | A    | L1    | 2025-10-06 14:58:01.700 | 2025-10-06 15:00:01.700 |       0.41 |       0.41 |       0.41 |      3 | 2025-10-15 07:55:00.100 |

```


```
select *
from dbt_dev1.interval_data
where transaction_id = '1014'
    and measurand = 'Energy.Active.Import.Register'
    and phase is null;
```

```
| CHARGE_POINT_ID | TRANSACTION_ID | INGESTED_TS             | CONNECTOR_ID | MEASURAND                     | UNIT | PHASE | METER_15MIN_INTERVAL_START | METER_15MIN_INTERVAL_STOP |  AVG_VALUE | _COUNT | INCREMENTAL_TS          |
| :-------------- | -------------: | :---------------------- | -----------: | :---------------------------- | :--- | :---- | :------------------------- | :------------------------ | ---------: | -----: | :---------------------- |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Energy.Active.Import.Register | Wh   | nan   | 2025-10-06 14:58:01.700    | 2025-10-06 15:00:00.000   | 2.3004e+06 |      2 | 2025-10-15 07:55:00.100 |
| CH-001          |           1014 | 2025-10-06 14:57:01.200 |            1 | Energy.Active.Import.Register | Wh   | nan   | 2025-10-06 15:00:00.000    | 2025-10-06 15:00:01.700   | 2.3004e+06 |      1 | 2025-10-15 07:55:00.100 |

```

Tableau [dashboard](https://public.tableau.com/views/WIPkwwhatdemo/Intervaldata?:language=en-US&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)