### PR TITLE
more tests

### DIFF
--- a/models/staging/raw/staging.yml
+++ b/models/staging/raw/staging.yml
@@ -65,6 +65,13 @@ models:
         description: "Timestamp when the message was received"
         tests:
           - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - message_type_id
+              - unique_id
 
   - name: stg_ports
     description: "Staging model for ports/connectors data. Charger means a device with one or more charging ports and connectors for charging EVs, also referred to as Electric Vehicle Supply Equipment (EVSE). Charging port means the system within a charger that charges one EV. A charging port may have multiple connectors, but it can provide power to charge only one EV through one connector at a time."


### PR DESCRIPTION
  Reviewed every model's declared grain against its test coverage. Found two gaps:

  - stg_ocpp_logs — the model description declared grain as charge_point_id + message_type_id + unique_id but there was no
  uniqueness test enforcing it. Added dbt_utils.unique_combination_of_columns.
  - dim_dates — date_day is the natural key and MetricFlow time spine column with no unique or not_null test. Added both.

  Everything else was already covered: intermediate and mart models either have a unique_combination_of_columns model-level
  test on the natural key, or a surrogate key column tested with unique + not_null.