### PR TITLE
Ocpp Logs Generator

### DIFF
--- a/demo/logs-generator/README.md
+++ b/demo/logs-generator/README.md
@@ -1,0 +1,21 @@
+# OCPP Log Simulator
+
+Simple OCPP server/client simulator for generating synthetic charger logs.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run server
+
+```bash
+python server.py
+```
+
+## Run client
+
+```bash
+python client.py client.py --loops 100 --interval 0.2 --charge-point-id CH-001 --response-delay-ms 40 --response-delay-jitter-ms 0 --output ocpp_client_generated_logs.csv 
+```

--- a/demo/logs-generator/client.py
+++ b/demo/logs-generator/client.py
@@ -1,0 +1,554 @@
+# client.py
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import random
+import uuid
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import websockets
+
+from ocpp.v201 import ChargePoint as cp
+from ocpp.v201 import call, call_result, datatypes, enums
+
+
+def configure_logging() -> None:
+    # force=True ensures config is applied even if logging was set elsewhere.
+    logging.basicConfig(level=logging.INFO, force=True)
+    logging.getLogger("ocpp").setLevel(logging.INFO)
+
+
+def format_utc_z(dt: datetime | None = None) -> str:
+    value = dt or datetime.now(timezone.utc)
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def snake_to_camel(name: str) -> str:
+    parts = name.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+def to_camel(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {snake_to_camel(k): to_camel(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [to_camel(item) for item in value]
+    return value
+
+
+def normalize_response_payload(response: Any) -> dict[str, Any]:
+    if is_dataclass(response):
+        return to_camel(asdict(response))
+    return {}
+
+
+def read_ports(ports_path: Path, charge_point_id: str) -> list[tuple[int, int]]:
+    if not ports_path.exists():
+        return [(1, 1)]
+
+    connectors: list[tuple[int, int]] = []
+    with ports_path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        for row in reader:
+            if row.get("charge_point_id") != charge_point_id:
+                continue
+            connector_id_raw = row.get("connector_id")
+            evse_id_raw = row.get("port_id")
+            if not connector_id_raw or not connector_id_raw.isdigit():
+                continue
+            connector_id = int(connector_id_raw)
+            evse_id = int(evse_id_raw) if evse_id_raw and evse_id_raw.isdigit() else 1
+            connectors.append((evse_id, connector_id))
+
+    return sorted(set(connectors)) or [(1, 1)]
+
+
+class ChargePoint(cp):
+    def __init__(self, charge_point_id: str, connection: websockets.ClientConnection):
+        super().__init__(charge_point_id, connection)
+        self.charge_point_id = charge_point_id
+        self.current_transaction_id: str | None = None
+        self.current_meter_wh = random.randint(2_300_000, 2_305_000)
+        self.transaction_seq_no = 0
+
+    async def send_boot_notification(self):
+        request_payload = {
+            "chargingStation": {
+                "vendorName": "ACME",
+                "model": "UltraFast-200",
+                "serialNumber": f"UF200-{random.randint(1, 9999):04d}",
+                "firmwareVersion": "2.0.1",
+            },
+            "reason": "PowerUp",
+        }
+        request = call.BootNotification(
+            charging_station=datatypes.ChargingStationType(
+                vendor_name=request_payload["chargingStation"]["vendorName"],
+                model=request_payload["chargingStation"]["model"],
+                serial_number=request_payload["chargingStation"]["serialNumber"],
+                firmware_version=request_payload["chargingStation"]["firmwareVersion"],
+            ),
+            reason=enums.BootReasonEnumType.power_up,
+        )
+        response: call_result.BootNotification = await self.call(request)
+
+        if response.status == enums.RegistrationStatusEnumType.accepted:
+            print("Connected to central system.")
+        return request_payload, normalize_response_payload(response)
+
+    async def send_heartbeat(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        request_payload: dict[str, Any] = {}
+        response: call_result.Heartbeat = await self.call(call.Heartbeat())
+        return request_payload, normalize_response_payload(response)
+
+    async def send_status_notification(
+        self, evse_id: int, connector_id: int, status: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        connector_status_map = {
+            "Available": enums.ConnectorStatusEnumType.available,
+            "Preparing": enums.ConnectorStatusEnumType.occupied,
+            "Charging": enums.ConnectorStatusEnumType.occupied,
+            "Faulted": enums.ConnectorStatusEnumType.faulted,
+        }
+        connector_status = connector_status_map.get(
+            status, enums.ConnectorStatusEnumType.occupied
+        )
+        request_payload = {
+            "timestamp": format_utc_z(),
+            "connectorStatus": connector_status.value,
+            "evseId": evse_id,
+            "connectorId": connector_id,
+        }
+
+        request = call.StatusNotification(
+            timestamp=request_payload["timestamp"],
+            connector_status=connector_status,
+            evse_id=evse_id,
+            connector_id=request_payload["connectorId"],
+        )
+        response: call_result.StatusNotification = await self.call(request)
+        return request_payload, normalize_response_payload(response)
+
+    async def send_transaction_event_started(
+        self, evse_id: int, connector_id: int, id_tag: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        self.current_transaction_id = f"tx-{uuid.uuid4().hex[:8]}"
+        self.transaction_seq_no = 1
+        request_payload = {
+            "eventType": "Started",
+            "timestamp": format_utc_z(),
+            "triggerReason": "RemoteStart",
+            "seqNo": self.transaction_seq_no,
+            "transactionInfo": {
+                "transactionId": self.current_transaction_id,
+                "chargingState": "Charging",
+            },
+            "evse": {"id": evse_id, "connectorId": connector_id},
+            "idToken": {"idToken": id_tag, "type": "Central"},
+        }
+        request = call.TransactionEvent(
+            event_type=enums.TransactionEventEnumType.started,
+            timestamp=request_payload["timestamp"],
+            trigger_reason=enums.TriggerReasonEnumType.remote_start,
+            seq_no=self.transaction_seq_no,
+            transaction_info=datatypes.TransactionType(
+                transaction_id=self.current_transaction_id,
+                charging_state=enums.ChargingStateEnumType.charging,
+            ),
+            evse=datatypes.EVSEType(id=evse_id, connector_id=connector_id),
+            id_token=datatypes.IdTokenType(
+                id_token=id_tag, type=enums.IdTokenEnumType.central
+            ),
+        )
+        response: call_result.TransactionEvent = await self.call(request)
+        response_payload = normalize_response_payload(response)
+        return request_payload, response_payload
+
+    async def send_meter_values(self, evse_id: int) -> tuple[dict[str, Any], dict[str, Any]]:
+        self.current_meter_wh += random.randint(20, 120)
+        timestamp = format_utc_z()
+        meter_value = datatypes.MeterValueType(
+            timestamp=timestamp,
+            sampled_value=[
+                datatypes.SampledValueType(
+                    value=float(self.current_meter_wh),
+                    context=enums.ReadingContextEnumType.sample_periodic,
+                    measurand=enums.MeasurandEnumType.energy_active_import_register,
+                    unit_of_measure=datatypes.UnitOfMeasureType(unit="Wh"),
+                )
+            ],
+        )
+        request = call.MeterValues(
+            evse_id=evse_id,
+            meter_value=[meter_value],
+        )
+        response: call_result.MeterValues = await self.call(request)
+        request_payload = {
+            "evseId": evse_id,
+            "meterValue": [
+                {
+                    "timestamp": timestamp,
+                    "sampledValue": [
+                        {
+                            "value": str(self.current_meter_wh),
+                            "context": "Sample.Periodic",
+                            "measurand": "Energy.Active.Import.Register",
+                            "unit": "Wh",
+                        }
+                    ],
+                }
+            ],
+        }
+        return request_payload, normalize_response_payload(response)
+
+    async def send_transaction_event_ended(
+        self, evse_id: int, connector_id: int
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        stop_wh = self.current_meter_wh + random.randint(1, 30)
+        self.transaction_seq_no += 1
+        request_payload = {
+            "eventType": "Ended",
+            "timestamp": format_utc_z(),
+            "triggerReason": "EVDeparted",
+            "seqNo": self.transaction_seq_no,
+            "transactionInfo": {
+                "transactionId": self.current_transaction_id,
+                "stoppedReason": "EVDisconnected",
+                "chargingState": "Idle",
+            },
+            "evse": {"id": evse_id, "connectorId": connector_id},
+            "meterValue": [
+                {
+                    "timestamp": format_utc_z(),
+                    "sampledValue": [
+                        {
+                            "context": "Transaction.End",
+                            "measurand": "Energy.Active.Import.Register",
+                            "value": str(stop_wh),
+                            "unit": "Wh",
+                        }
+                    ],
+                }
+            ],
+        }
+        request = call.TransactionEvent(
+            event_type=enums.TransactionEventEnumType.ended,
+            timestamp=request_payload["timestamp"],
+            trigger_reason=enums.TriggerReasonEnumType.ev_departed,
+            seq_no=self.transaction_seq_no,
+            transaction_info=datatypes.TransactionType(
+                transaction_id=str(self.current_transaction_id),
+                charging_state=enums.ChargingStateEnumType.idle,
+                stopped_reason=enums.ReasonEnumType.ev_disconnected,
+            ),
+            meter_value=[
+                datatypes.MeterValueType(
+                    timestamp=request_payload["meterValue"][0]["timestamp"],
+                    sampled_value=[
+                        datatypes.SampledValueType(
+                            value=float(stop_wh),
+                            context=enums.ReadingContextEnumType.transaction_end,
+                            measurand=enums.MeasurandEnumType.energy_active_import_register,
+                            unit_of_measure=datatypes.UnitOfMeasureType(unit="Wh"),
+                        )
+                    ],
+                )
+            ],
+            evse=datatypes.EVSEType(id=evse_id, connector_id=connector_id),
+        )
+        response: call_result.TransactionEvent = await self.call(request)
+        return request_payload, normalize_response_payload(response)
+
+    async def send_repeated_actions(
+        self,
+        loops: int,
+        interval_s: float,
+        evse_id: int,
+        connector_id: int,
+        log_writer: "SessionLogWriter",
+        status_every: int,
+        fault_probability: float,
+    ) -> None:
+        for index in range(1, loops + 1):
+            if status_every > 0 and index % status_every == 0:
+                preparing_req, preparing_res = await self.send_status_notification(
+                    evse_id=evse_id, connector_id=connector_id, status="Preparing"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=preparing_req,
+                    response_payload=preparing_res,
+                    msg_prefix="notif",
+                )
+                charging_req, charging_res = await self.send_status_notification(
+                    evse_id=evse_id, connector_id=connector_id, status="Charging"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=charging_req,
+                    response_payload=charging_res,
+                    msg_prefix="notif",
+                )
+
+            if random.random() < fault_probability:
+                fault_req, fault_res = await self.send_status_notification(
+                    evse_id=evse_id,
+                    connector_id=connector_id,
+                    status="Faulted",
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=fault_req,
+                    response_payload=fault_res,
+                    msg_prefix="notif",
+                )
+                recover_req, recover_res = await self.send_status_notification(
+                    evse_id=evse_id, connector_id=connector_id, status="Available"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=recover_req,
+                    response_payload=recover_res,
+                    msg_prefix="notif",
+                )
+                resume_req, resume_res = await self.send_status_notification(
+                    evse_id=evse_id, connector_id=connector_id, status="Charging"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=resume_req,
+                    response_payload=resume_res,
+                    msg_prefix="notif",
+                )
+
+            hb_req, hb_res = await self.send_heartbeat()
+            log_writer.log_exchange(
+                charge_point_id=self.charge_point_id,
+                action="Heartbeat",
+                request_payload=hb_req,
+                response_payload=hb_res,
+                msg_prefix="hb",
+            )
+            meter_req, meter_res = await self.send_meter_values(evse_id)
+            log_writer.log_exchange(
+                charge_point_id=self.charge_point_id,
+                action="MeterValues",
+                request_payload=meter_req,
+                response_payload=meter_res,
+                msg_prefix="meter",
+            )
+            await asyncio.sleep(interval_s)
+
+
+class SessionLogWriter:
+    def __init__(self, output: Path):
+        self.output = output
+        self.file = output.open("w", encoding="utf-8", newline="")
+        self.writer = csv.DictWriter(self.file, fieldnames=["timestamp", "id", "action", "msg"])
+        self.writer.writeheader()
+
+    def close(self) -> None:
+        self.file.close()
+
+    def _write_row(self, timestamp: str, charge_point_id: str, action: str, msg: list[Any]) -> None:
+        self.writer.writerow(
+            {
+                "timestamp": timestamp,
+                "id": charge_point_id,
+                "action": action,
+                "msg": json.dumps(msg, separators=(",", ":")),
+            }
+        )
+
+    def log_exchange(
+        self,
+        charge_point_id: str,
+        action: str,
+        request_payload: dict[str, Any],
+        response_payload: dict[str, Any],
+        msg_prefix: str,
+    ) -> None:
+        msg_id = f"{msg_prefix}-{uuid.uuid4().hex[:5]}"
+        request_time = format_utc_z()
+        response_time = format_utc_z(datetime.now(timezone.utc))
+        self._write_row(request_time, charge_point_id, action, [2, msg_id, action, request_payload])
+        self._write_row(response_time, charge_point_id, "", [3, msg_id, response_payload])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run OCPP charge point client traffic.")
+    parser.add_argument(
+        "--loops",
+        type=int,
+        default=10,
+        help="How many heartbeat/meter cycles to send (default: 10).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Delay between cycles in seconds (default: 1.0).",
+    )
+    parser.add_argument(
+        "--charge-point-id",
+        default="CH-002",
+        help="Charge point id used in URL and output logs (default: CH-002).",
+    )
+    parser.add_argument(
+        "--ports-file",
+        type=Path,
+        default=Path("ports.csv"),
+        help="Ports CSV used to derive connector ids (default: ports.csv).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ocpp_client_generated_logs.csv"),
+        help="Output CSV path with columns timestamp,id,action,msg.",
+    )
+    parser.add_argument(
+        "--status-every",
+        type=int,
+        default=10,
+        help="Emit Preparing/Charging StatusNotification every N loops (default: 10).",
+    )
+    parser.add_argument(
+        "--fault-probability",
+        type=float,
+        default=0.05,
+        help="Chance of a fault/recovery status sequence per loop (default: 0.05).",
+    )
+    return parser.parse_args()
+
+
+async def main(
+    loops: int,
+    interval_s: float,
+    charge_point_id: str,
+    ports_file: Path,
+    output: Path,
+    status_every: int,
+    fault_probability: float,
+):
+    connector_ids = read_ports(ports_file, charge_point_id)
+    log_writer = SessionLogWriter(output)
+    start_task: asyncio.Task | None = None
+    async with websockets.connect(
+        f"ws://localhost:9000/{charge_point_id}", subprotocols=["ocpp2.0.1"]
+    ) as ws:
+        charge_point = ChargePoint(charge_point_id, ws)
+        start_task = asyncio.create_task(charge_point.start())
+
+        boot_req, boot_res = await charge_point.send_boot_notification()
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="BootNotification",
+            request_payload=boot_req,
+            response_payload=boot_res,
+            msg_prefix="boot",
+        )
+
+        for evse_id, connector_id in connector_ids:
+            sn_req, sn_res = await charge_point.send_status_notification(
+                evse_id=evse_id, connector_id=connector_id, status="Available"
+            )
+            log_writer.log_exchange(
+                charge_point_id=charge_point_id,
+                action="StatusNotification",
+                request_payload=sn_req,
+                response_payload=sn_res,
+                msg_prefix="notif",
+            )
+
+        evse_id, connector_id = connector_ids[0]
+        start_req, start_res = await charge_point.send_transaction_event_started(
+            evse_id=evse_id,
+            connector_id=connector_id,
+            id_tag=f"ABC{random.randint(100, 999)}XYZ",
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="TransactionEvent",
+            request_payload=start_req,
+            response_payload=start_res,
+            msg_prefix="tx",
+        )
+
+        charging_req, charging_res = await charge_point.send_status_notification(
+            evse_id=evse_id, connector_id=connector_id, status="Charging"
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StatusNotification",
+            request_payload=charging_req,
+            response_payload=charging_res,
+            msg_prefix="notif",
+        )
+
+        await charge_point.send_repeated_actions(
+            loops=loops,
+            interval_s=interval_s,
+            evse_id=evse_id,
+            connector_id=connector_id,
+            log_writer=log_writer,
+            status_every=status_every,
+            fault_probability=fault_probability,
+        )
+
+        stop_req, stop_res = await charge_point.send_transaction_event_ended(
+            evse_id=evse_id, connector_id=connector_id
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="TransactionEvent",
+            request_payload=stop_req,
+            response_payload=stop_res,
+            msg_prefix="stop",
+        )
+
+        final_req, final_res = await charge_point.send_status_notification(
+            evse_id=evse_id, connector_id=connector_id, status="Available"
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StatusNotification",
+            request_payload=final_req,
+            response_payload=final_res,
+            msg_prefix="notif",
+        )
+
+        await ws.close()
+    try:
+        if start_task is not None:
+            await start_task
+    except websockets.exceptions.ConnectionClosed:
+        # Expected when we close the socket after finishing traffic generation.
+        pass
+    finally:
+        log_writer.close()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    configure_logging()
+    asyncio.run(
+        main(
+            loops=args.loops,
+            interval_s=args.interval,
+            charge_point_id=args.charge_point_id,
+            ports_file=args.ports_file,
+            output=args.output,
+            status_every=args.status_every,
+            fault_probability=args.fault_probability,
+        )
+    )

--- a/demo/logs-generator/client.py
+++ b/demo/logs-generator/client.py
@@ -6,8 +6,9 @@ import json
 import logging
 import random
 import uuid
+from collections import defaultdict
 from dataclasses import asdict, is_dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -351,8 +352,16 @@ class ChargePoint(cp):
 
 
 class SessionLogWriter:
-    def __init__(self, output: Path):
+    def __init__(
+        self,
+        output: Path,
+        response_delay_ms: int = 40,
+        response_delay_jitter_ms: int = 10,
+    ):
         self.output = output
+        self.response_delay_ms = max(0, response_delay_ms)
+        self.response_delay_jitter_ms = max(0, response_delay_jitter_ms)
+        self.message_counters: dict[str, int] = defaultdict(int)
         self.file = output.open("w", encoding="utf-8", newline="")
         self.writer = csv.DictWriter(self.file, fieldnames=["timestamp", "id", "action", "msg"])
         self.writer.writeheader()
@@ -378,9 +387,15 @@ class SessionLogWriter:
         response_payload: dict[str, Any],
         msg_prefix: str,
     ) -> None:
-        msg_id = f"{msg_prefix}-{uuid.uuid4().hex[:5]}"
-        request_time = format_utc_z()
-        response_time = format_utc_z(datetime.now(timezone.utc))
+        self.message_counters[msg_prefix] += 1
+        msg_id = f"{msg_prefix}-{self.message_counters[msg_prefix]:05d}"
+        request_dt = datetime.now(timezone.utc)
+        response_dt = request_dt + timedelta(
+            milliseconds=self.response_delay_ms
+            + random.randint(0, self.response_delay_jitter_ms)
+        )
+        request_time = format_utc_z(request_dt)
+        response_time = format_utc_z(response_dt)
         self._write_row(request_time, charge_point_id, action, [2, msg_id, action, request_payload])
         self._write_row(response_time, charge_point_id, "", [3, msg_id, response_payload])
 
@@ -428,6 +443,18 @@ def parse_args() -> argparse.Namespace:
         default=0.05,
         help="Chance of a fault/recovery status sequence per loop (default: 0.05).",
     )
+    parser.add_argument(
+        "--response-delay-ms",
+        type=int,
+        default=40,
+        help="Base response spacing in CSV rows (default: 40ms).",
+    )
+    parser.add_argument(
+        "--response-delay-jitter-ms",
+        type=int,
+        default=10,
+        help="Extra random response delay jitter in ms (default: 10).",
+    )
     return parser.parse_args()
 
 
@@ -439,9 +466,15 @@ async def main(
     output: Path,
     status_every: int,
     fault_probability: float,
+    response_delay_ms: int,
+    response_delay_jitter_ms: int,
 ):
     connector_ids = read_ports(ports_file, charge_point_id)
-    log_writer = SessionLogWriter(output)
+    log_writer = SessionLogWriter(
+        output,
+        response_delay_ms=response_delay_ms,
+        response_delay_jitter_ms=response_delay_jitter_ms,
+    )
     start_task: asyncio.Task | None = None
     async with websockets.connect(
         f"ws://localhost:9000/{charge_point_id}", subprotocols=["ocpp2.0.1"]
@@ -550,5 +583,7 @@ if __name__ == "__main__":
             output=args.output,
             status_every=args.status_every,
             fault_probability=args.fault_probability,
+            response_delay_ms=args.response_delay_ms,
+            response_delay_jitter_ms=args.response_delay_jitter_ms,
         )
     )

--- a/demo/logs-generator/client1_6.py
+++ b/demo/logs-generator/client1_6.py
@@ -1,0 +1,495 @@
+# client.py
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import random
+import uuid
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import websockets
+
+from ocpp.v16 import ChargePoint as cp
+from ocpp.v16 import call, call_result
+from ocpp.v16.enums import RegistrationStatus
+
+
+def configure_logging() -> None:
+    # force=True ensures config is applied even if logging was set elsewhere.
+    logging.basicConfig(level=logging.INFO, force=True)
+    logging.getLogger("ocpp").setLevel(logging.INFO)
+
+
+def format_utc_z(dt: datetime | None = None) -> str:
+    value = dt or datetime.now(timezone.utc)
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def snake_to_camel(name: str) -> str:
+    parts = name.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+def to_camel(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {snake_to_camel(k): to_camel(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [to_camel(item) for item in value]
+    return value
+
+
+def normalize_response_payload(response: Any) -> dict[str, Any]:
+    if is_dataclass(response):
+        return to_camel(asdict(response))
+    return {}
+
+
+def read_ports(ports_path: Path, charge_point_id: str) -> list[int]:
+    if not ports_path.exists():
+        return [1]
+
+    connector_ids: list[int] = []
+    with ports_path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        for row in reader:
+            if row.get("charge_point_id") != charge_point_id:
+                continue
+            connector_id = row.get("connector_id")
+            if connector_id and connector_id.isdigit():
+                connector_ids.append(int(connector_id))
+
+    return sorted(set(connector_ids)) or [1]
+
+
+class ChargePoint(cp):
+    def __init__(self, charge_point_id: str, connection: websockets.ClientConnection):
+        super().__init__(charge_point_id, connection)
+        self.charge_point_id = charge_point_id
+        self.current_transaction_id: int | None = None
+        self.current_meter_wh = random.randint(2_300_000, 2_305_000)
+
+    async def send_boot_notification(self):
+        request_payload = {
+            "chargePointVendor": "ACME",
+            "chargePointModel": "UltraFast-200",
+            "chargePointSerialNumber": f"UF200-{random.randint(1, 9999):04d}",
+            "firmwareVersion": "1.6.7",
+        }
+        request = call.BootNotification(
+            charge_point_vendor=request_payload["chargePointVendor"],
+            charge_point_model=request_payload["chargePointModel"],
+            charge_point_serial_number=request_payload["chargePointSerialNumber"],
+            firmware_version=request_payload["firmwareVersion"],
+        )
+        response: call_result.BootNotification = await self.call(request)
+
+        if response.status == RegistrationStatus.accepted:
+            print("Connected to central system.")
+        return request_payload, normalize_response_payload(response)
+
+    async def send_heartbeat(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        request_payload: dict[str, Any] = {}
+        response: call_result.Heartbeat = await self.call(call.Heartbeat())
+        return request_payload, normalize_response_payload(response)
+
+    async def send_status_notification(
+        self, connector_id: int, status: str, error_code: str = "NoError"
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        request_payload = {
+            "connectorId": connector_id,
+            "status": status,
+            "errorCode": error_code,
+            "timestamp": format_utc_z(),
+        }
+        if error_code != "NoError":
+            request_payload["info"] = "Synthetic connector issue"
+
+        request = call.StatusNotification(
+            connector_id=request_payload["connectorId"],
+            status=request_payload["status"],
+            error_code=request_payload["errorCode"],
+            timestamp=request_payload["timestamp"],
+            info=request_payload.get("info"),
+        )
+        response: call_result.StatusNotification = await self.call(request)
+        return request_payload, normalize_response_payload(response)
+
+    async def send_start_transaction(
+        self, connector_id: int, id_tag: str
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        request_payload = {
+            "connectorId": connector_id,
+            "idTag": id_tag,
+            "timestamp": format_utc_z(),
+            "meterStart": self.current_meter_wh,
+        }
+        request = call.StartTransaction(
+            connector_id=request_payload["connectorId"],
+            id_tag=request_payload["idTag"],
+            timestamp=request_payload["timestamp"],
+            meter_start=request_payload["meterStart"],
+        )
+        response: call_result.StartTransaction = await self.call(request)
+        response_payload = normalize_response_payload(response)
+        self.current_transaction_id = int(response_payload["transactionId"])
+        return request_payload, response_payload
+
+    async def send_meter_values(self, connector_id: int) -> tuple[dict[str, Any], dict[str, Any]]:
+        self.current_meter_wh += random.randint(20, 120)
+        timestamp = format_utc_z()
+        request = call.MeterValues(
+            connector_id=connector_id,
+            transaction_id=self.current_transaction_id,
+            meter_value=[
+                {
+                    "timestamp": timestamp,
+                    "sampled_value": [
+                        {
+                            "value": str(self.current_meter_wh),
+                            "context": "Sample.Periodic",
+                            "measurand": "Energy.Active.Import.Register",
+                            "unit": "Wh",
+                        }
+                    ],
+                }
+            ],
+        )
+        response: call_result.MeterValues = await self.call(request)
+        request_payload = {
+            "connectorId": connector_id,
+            "transactionId": self.current_transaction_id,
+            "meterValue": [
+                {
+                    "timestamp": timestamp,
+                    "sampledValue": [
+                        {
+                            "value": str(self.current_meter_wh),
+                            "context": "Sample.Periodic",
+                            "measurand": "Energy.Active.Import.Register",
+                            "unit": "Wh",
+                        }
+                    ],
+                }
+            ],
+        }
+        return request_payload, normalize_response_payload(response)
+
+    async def send_stop_transaction(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        stop_wh = self.current_meter_wh + random.randint(1, 30)
+        transaction_data = [
+            {
+                "timestamp": format_utc_z(),
+                "sampledValue": [
+                    {
+                        "context": "Transaction.End",
+                        "measurand": "Energy.Active.Import.Register",
+                        "value": str(stop_wh),
+                        "unit": "Wh",
+                    }
+                ],
+            }
+        ]
+        request_payload = {
+            "transactionId": self.current_transaction_id,
+            "meterStop": stop_wh,
+            "timestamp": format_utc_z(),
+            "reason": "EVDisconnected",
+            "transactionData": transaction_data,
+        }
+        request = call.StopTransaction(
+            transaction_id=request_payload["transactionId"],
+            meter_stop=request_payload["meterStop"],
+            timestamp=request_payload["timestamp"],
+            reason=request_payload["reason"],
+            transaction_data=transaction_data,
+        )
+        response: call_result.StopTransaction = await self.call(request)
+        return request_payload, normalize_response_payload(response)
+
+    async def send_repeated_actions(
+        self,
+        loops: int,
+        interval_s: float,
+        connector_id: int,
+        log_writer: "SessionLogWriter",
+        status_every: int,
+        fault_probability: float,
+    ) -> None:
+        for index in range(1, loops + 1):
+            if status_every > 0 and index % status_every == 0:
+                preparing_req, preparing_res = await self.send_status_notification(
+                    connector_id=connector_id, status="Preparing"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=preparing_req,
+                    response_payload=preparing_res,
+                    msg_prefix="notif",
+                )
+                charging_req, charging_res = await self.send_status_notification(
+                    connector_id=connector_id, status="Charging"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=charging_req,
+                    response_payload=charging_res,
+                    msg_prefix="notif",
+                )
+
+            if random.random() < fault_probability:
+                fault_req, fault_res = await self.send_status_notification(
+                    connector_id=connector_id,
+                    status="Faulted",
+                    error_code="ConnectorLockFailure",
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=fault_req,
+                    response_payload=fault_res,
+                    msg_prefix="notif",
+                )
+                recover_req, recover_res = await self.send_status_notification(
+                    connector_id=connector_id, status="Available"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=recover_req,
+                    response_payload=recover_res,
+                    msg_prefix="notif",
+                )
+                resume_req, resume_res = await self.send_status_notification(
+                    connector_id=connector_id, status="Charging"
+                )
+                log_writer.log_exchange(
+                    charge_point_id=self.charge_point_id,
+                    action="StatusNotification",
+                    request_payload=resume_req,
+                    response_payload=resume_res,
+                    msg_prefix="notif",
+                )
+
+            hb_req, hb_res = await self.send_heartbeat()
+            log_writer.log_exchange(
+                charge_point_id=self.charge_point_id,
+                action="Heartbeat",
+                request_payload=hb_req,
+                response_payload=hb_res,
+                msg_prefix="hb",
+            )
+            meter_req, meter_res = await self.send_meter_values(connector_id)
+            log_writer.log_exchange(
+                charge_point_id=self.charge_point_id,
+                action="MeterValues",
+                request_payload=meter_req,
+                response_payload=meter_res,
+                msg_prefix="meter",
+            )
+            await asyncio.sleep(interval_s)
+
+
+class SessionLogWriter:
+    def __init__(self, output: Path):
+        self.output = output
+        self.file = output.open("w", encoding="utf-8", newline="")
+        self.writer = csv.DictWriter(self.file, fieldnames=["timestamp", "id", "action", "msg"])
+        self.writer.writeheader()
+
+    def close(self) -> None:
+        self.file.close()
+
+    def _write_row(self, timestamp: str, charge_point_id: str, action: str, msg: list[Any]) -> None:
+        self.writer.writerow(
+            {
+                "timestamp": timestamp,
+                "id": charge_point_id,
+                "action": action,
+                "msg": json.dumps(msg, separators=(",", ":")),
+            }
+        )
+
+    def log_exchange(
+        self,
+        charge_point_id: str,
+        action: str,
+        request_payload: dict[str, Any],
+        response_payload: dict[str, Any],
+        msg_prefix: str,
+    ) -> None:
+        msg_id = f"{msg_prefix}-{uuid.uuid4().hex[:5]}"
+        request_time = format_utc_z()
+        response_time = format_utc_z(datetime.now(timezone.utc))
+        self._write_row(request_time, charge_point_id, action, [2, msg_id, action, request_payload])
+        self._write_row(response_time, charge_point_id, "", [3, msg_id, response_payload])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run OCPP charge point client traffic.")
+    parser.add_argument(
+        "--loops",
+        type=int,
+        default=10,
+        help="How many heartbeat/meter cycles to send (default: 10).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Delay between cycles in seconds (default: 1.0).",
+    )
+    parser.add_argument(
+        "--charge-point-id",
+        default="CH-002",
+        help="Charge point id used in URL and output logs (default: CH-002).",
+    )
+    parser.add_argument(
+        "--ports-file",
+        type=Path,
+        default=Path("ports.csv"),
+        help="Ports CSV used to derive connector ids (default: ports.csv).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ocpp_client_generated_logs.csv"),
+        help="Output CSV path with columns timestamp,id,action,msg.",
+    )
+    parser.add_argument(
+        "--status-every",
+        type=int,
+        default=10,
+        help="Emit Preparing/Charging StatusNotification every N loops (default: 10).",
+    )
+    parser.add_argument(
+        "--fault-probability",
+        type=float,
+        default=0.05,
+        help="Chance of a fault/recovery status sequence per loop (default: 0.05).",
+    )
+    return parser.parse_args()
+
+
+async def main(
+    loops: int,
+    interval_s: float,
+    charge_point_id: str,
+    ports_file: Path,
+    output: Path,
+    status_every: int,
+    fault_probability: float,
+):
+    connector_ids = read_ports(ports_file, charge_point_id)
+    log_writer = SessionLogWriter(output)
+    start_task: asyncio.Task | None = None
+    async with websockets.connect(
+        f"ws://localhost:9000/{charge_point_id}", subprotocols=["ocpp2.0.1"]
+    ) as ws:
+        charge_point = ChargePoint(charge_point_id, ws)
+        start_task = asyncio.create_task(charge_point.start())
+
+        boot_req, boot_res = await charge_point.send_boot_notification()
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="BootNotification",
+            request_payload=boot_req,
+            response_payload=boot_res,
+            msg_prefix="boot",
+        )
+
+        for connector_id in connector_ids:
+            sn_req, sn_res = await charge_point.send_status_notification(
+                connector_id=connector_id, status="Available"
+            )
+            log_writer.log_exchange(
+                charge_point_id=charge_point_id,
+                action="StatusNotification",
+                request_payload=sn_req,
+                response_payload=sn_res,
+                msg_prefix="notif",
+            )
+
+        connector_id = connector_ids[0]
+        start_req, start_res = await charge_point.send_start_transaction(
+            connector_id=connector_id,
+            id_tag=f"ABC{random.randint(100, 999)}XYZ",
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StartTransaction",
+            request_payload=start_req,
+            response_payload=start_res,
+            msg_prefix="tx",
+        )
+
+        charging_req, charging_res = await charge_point.send_status_notification(
+            connector_id=connector_id, status="Charging"
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StatusNotification",
+            request_payload=charging_req,
+            response_payload=charging_res,
+            msg_prefix="notif",
+        )
+
+        await charge_point.send_repeated_actions(
+            loops=loops,
+            interval_s=interval_s,
+            connector_id=connector_id,
+            log_writer=log_writer,
+            status_every=status_every,
+            fault_probability=fault_probability,
+        )
+
+        stop_req, stop_res = await charge_point.send_stop_transaction()
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StopTransaction",
+            request_payload=stop_req,
+            response_payload=stop_res,
+            msg_prefix="stop",
+        )
+
+        final_req, final_res = await charge_point.send_status_notification(
+            connector_id=connector_id, status="Available"
+        )
+        log_writer.log_exchange(
+            charge_point_id=charge_point_id,
+            action="StatusNotification",
+            request_payload=final_req,
+            response_payload=final_res,
+            msg_prefix="notif",
+        )
+
+        await ws.close()
+    try:
+        if start_task is not None:
+            await start_task
+    except websockets.exceptions.ConnectionClosed:
+        # Expected when we close the socket after finishing traffic generation.
+        pass
+    finally:
+        log_writer.close()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    configure_logging()
+    asyncio.run(
+        main(
+            loops=args.loops,
+            interval_s=args.interval,
+            charge_point_id=args.charge_point_id,
+            ports_file=args.ports_file,
+            output=args.output,
+            status_every=args.status_every,
+            fault_probability=args.fault_probability,
+        )
+    )

--- a/demo/logs-generator/requirements.txt
+++ b/demo/logs-generator/requirements.txt
@@ -1,0 +1,2 @@
+ocpp==2.1.0
+websockets==16.0

--- a/demo/logs-generator/server.py
+++ b/demo/logs-generator/server.py
@@ -1,0 +1,64 @@
+# server.py
+import asyncio
+
+from datetime import datetime, timezone
+import websockets
+
+from ocpp.routing import on
+from ocpp.v201 import ChargePoint as cp
+from ocpp.v201 import call_result
+from ocpp.v201.enums import Action, RegistrationStatusEnumType
+
+
+class MyChargePoint(cp):
+    @on(Action.boot_notification)
+    async def on_boot_notification(self, **kwargs):
+        return call_result.BootNotification(
+            current_time=datetime.now(tz=timezone.utc).isoformat(),
+            interval=10,
+            status=RegistrationStatusEnumType.accepted,
+        )
+
+    @on(Action.heartbeat)
+    async def on_heartbeat(self, **kwargs):
+        return call_result.Heartbeat(
+            current_time=datetime.now(tz=timezone.utc).isoformat()
+        )
+
+    @on(Action.meter_values)
+    async def on_meter_values(self, **kwargs):
+        return call_result.MeterValues()
+
+    @on(Action.status_notification)
+    async def on_status_notification(self, **kwargs):
+        return call_result.StatusNotification()
+
+    @on(Action.transaction_event)
+    async def on_transaction_event(self, **kwargs):
+        return call_result.TransactionEvent()
+
+
+async def on_connect(connection: websockets.ServerConnection):
+    """
+    For every new connection, create a new ChargePoint instance,
+    and start listening for messages.
+    """
+    charge_point_id = connection.request.path.split("/")[-1]
+    charge_point = MyChargePoint(charge_point_id, connection)
+    try:
+        await charge_point.start()
+    except websockets.exceptions.ConnectionClosedOK:
+        # Normal shutdown when client closes after sending a finite test run.
+        pass
+
+async def main():
+    server = await websockets.serve(
+        on_connect,
+        '0.0.0.0',
+        9000,
+        subprotocols=["ocpp2.0.1"],
+    )
+    await server.wait_closed()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/demo/logs-generator/server1_6.py
+++ b/demo/logs-generator/server1_6.py
@@ -1,0 +1,73 @@
+# server.py
+import asyncio
+import itertools
+
+from datetime import datetime, timezone
+import websockets
+
+from ocpp.routing import on
+from ocpp.v16 import ChargePoint as cp
+from ocpp.v16 import call_result
+from ocpp.v16.enums import Action, RegistrationStatus
+
+
+class MyChargePoint(cp):
+    _transaction_id_counter = itertools.count(5001)
+
+    @on(Action.boot_notification)
+    async def on_boot_notification(
+        self, charge_point_vendor, charge_point_model, **kwargs
+    ):
+        return call_result.BootNotification(
+            current_time=datetime.now(tz=timezone.utc).isoformat(),
+            interval=10,
+            status=RegistrationStatus.accepted,
+        )
+
+    @on(Action.heartbeat)
+    async def on_heartbeat(self, **kwargs):
+        return call_result.Heartbeat(
+            current_time=datetime.now(tz=timezone.utc).isoformat()
+        )
+
+    @on(Action.meter_values)
+    async def on_meter_values(self, **kwargs):
+        return call_result.MeterValues()
+
+    @on(Action.status_notification)
+    async def on_status_notification(self, **kwargs):
+        return call_result.StatusNotification()
+
+    @on(Action.start_transaction)
+    async def on_start_transaction(self, id_tag, **kwargs):
+        return call_result.StartTransaction(
+            transaction_id=next(self._transaction_id_counter),
+            id_tag_info={"status": "Accepted"},
+        )
+
+    @on(Action.stop_transaction)
+    async def on_stop_transaction(self, **kwargs):
+        return call_result.StopTransaction(id_tag_info={"status": "Accepted"})
+
+
+async def on_connect(connection: websockets.ServerConnection):
+    """
+    For every new connection, create a new ChargePoint instance,
+    and start listening for messages.
+    """
+    charge_point_id = connection.request.path.split("/")[-1]
+    charge_point = MyChargePoint(charge_point_id, connection)
+
+    await charge_point.start()
+
+async def main():
+    server = await websockets.serve(
+        on_connect,
+        '0.0.0.0',
+        9000,
+        subprotocols=["ocpp2.0.1"],
+    )
+    await server.wait_closed()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
Add OCPP v2.0.1 client/server log generator.
                                                                                                                                                                                                                                                                       
Adds a WebSocket-based OCPP v2.0.1 charging session simulator that produces realistic CSV logs for testing and analysis.                                                                                                                                             
                                                                                                                                                                                                                                                                       
server.py is a minimal central system listener (port 9000) that accepts connections and responds to all standard actions. client.py drives a full charging session - BootNotification, StatusNotification, TransactionEvent (start/end), Heartbeat, and MeterValues - and writes every request/response pair to a CSV with columns timestamp, id, action, msg.                                                                                                                                                                            
                                                                                                                                                                                                                                                                       
Key client options: --loops, --interval, --charge-point-id, --fault-probability (random Faulted/recovery sequences), --status-every, and --response-delay-ms/--response-delay-jitter-ms to control the simulated round-trip timing in the output.

OCPP v1.6 support implemented in *1.6 files