### PR TITLE
dbt skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "dbt@dbt-agent-marketplace": true
+  }
+}


### PR DESCRIPTION
Add .claude/settings.json to enable [dbt agent skills](https://github.com/dbt-labs/dbt-agent-skills)

  This file configures Claude Code for this project. It enables the dbt-labs/dbt-agent-skills plugin, which gives Claude specialised skills for dbt work: building models, writing unit tests, querying the Semantic Layer, troubleshooting job failures, and more.

  Without this file, Claude Code loads no project-level plugins and the dbt skills are unavailable. With it, every teammate who opens this repo in Claude Code gets the same capabilities automatically.

  --- How to activate (first time or after pulling this file) ---

  1. Open this repo in Claude Code.
  2. Run:  /reload-plugins
  3. Run:  /skills
     You should see a list of dbt:* skills (building-dbt-semantic-layer, using-dbt-for-analytics-engineering, adding-dbt-unit-test, etc.).

<img width="1078" height="365" alt="Screenshot 2026-05-23 at 9 31 06 AM" src="https://github.com/user-attachments/assets/ab1e58e6-6d58-4afc-8139-197e7fe821ff" />


  If /skills shows "No skills found", run /reload-plugins again — the plugin must be reloaded before skills register.

  --- How to check it is working ---

  Ask Claude something dbt-specific, e.g.:
    "Run dbt build for the fact_sessions model"
    "Add a unit test for int_charge_attempts"

  Claude will invoke the matching dbt skill automatically instead of falling back to generic shell commands.
  
  
  --- Ask questions in natural language example ---

<img width="993" height="336" alt="Screenshot 2026-05-23 at 9 43 54 AM" src="https://github.com/user-attachments/assets/baf78865-af9a-42d8-b965-ffb6fbe1f227" />

I need to fix 👆eventually because we have 8 connectors (maybe) not ports. 