### PR TITLE
Add not_null and unique tests to dim_dates primary key

### DIFF
--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -279,6 +279,11 @@ models:
     time_spine:
       standard_granularity_column: date_day
     columns:
+      - name: date_id
+        description: "Primary key for the date dimension. One row per calendar day; identical to date_day."
+        tests:
+          - not_null
+          - unique
       - name: date_day
         description: "Date at day granularity; used as time spine standard granularity column"
         granularity: day


### PR DESCRIPTION
## Summary

- Closes #101
- `dim_dates.date_id` had no data quality tests on its primary key column — a null or duplicate date row causes fan-out in every time-series metric downstream
- Added `not_null` and `unique` tests to `date_id` in `models/marts/marts.yml` and declared the column in the columns block
- No SQL changes to `dim_dates.sql`

## Test plan

- [ ] `dbt test --select dim_dates` passes with PASS=2 WARN=0 ERROR=0
- [ ] `not_null_dim_dates_date_id` passes
- [ ] `unique_dim_dates_date_id` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)