### PR TITLE
Feature/dim drivers

### DIFF
--- a/macros/max_by.sql
+++ b/macros/max_by.sql
@@ -3,16 +3,6 @@
 {% endmacro %}
 
 {% macro default__max_by(value, order_col) %}
-    {{ exceptions.raise_compiler_error(
-        "max_by not implemented for adapter " ~ target.type
-    ) }}
-{% endmacro %}
-
-{% macro snowflake__max_by(value, order_col) %}
-    max_by({{ value }}, {{ order_col }})
-{% endmacro %}
-
-{% macro duckdb__max_by(value, order_col) %}
     max_by({{ value }}, {{ order_col }})
 {% endmacro %}
 
@@ -24,14 +14,11 @@
     (array_agg({{ value }} order by {{ order_col }} desc))[1]
 {% endmacro %}
 
+# Dont forget to cast from varchar if needed  #
 {% macro redshift__max_by(value, order_col) %}
-    (array_agg({{ value }} order by {{ order_col }} desc))[1]
-{% endmacro %}
-
-{% macro trino__max_by(value, order_col) %}
-    max_by({{ value }}, {{ order_col }})
-{% endmacro %}
-
-{% macro presto__max_by(value, order_col) %}
-    max_by({{ value }}, {{ order_col }})
+    SPLIT_PART(
+        LISTAGG({{ value }}::varchar, CHR(1)) WITHIN GROUP (ORDER BY {{ order_col }} DESC),
+        CHR(1),
+        1
+    )
 {% endmacro %}

--- a/macros/max_by.sql
+++ b/macros/max_by.sql
@@ -1,0 +1,37 @@
+{% macro max_by(value, order_col) %}
+    {{ return(adapter.dispatch('max_by', 'kwwhat')(value, order_col)) }}
+{% endmacro %}
+
+{% macro default__max_by(value, order_col) %}
+    {{ exceptions.raise_compiler_error(
+        "max_by not implemented for adapter " ~ target.type
+    ) }}
+{% endmacro %}
+
+{% macro snowflake__max_by(value, order_col) %}
+    max_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro duckdb__max_by(value, order_col) %}
+    max_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro bigquery__max_by(value, order_col) %}
+    any_value({{ value }} having max {{ order_col }})
+{% endmacro %}
+
+{% macro postgres__max_by(value, order_col) %}
+    (array_agg({{ value }} order by {{ order_col }} desc))[1]
+{% endmacro %}
+
+{% macro redshift__max_by(value, order_col) %}
+    (array_agg({{ value }} order by {{ order_col }} desc))[1]
+{% endmacro %}
+
+{% macro trino__max_by(value, order_col) %}
+    max_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro presto__max_by(value, order_col) %}
+    max_by({{ value }}, {{ order_col }})
+{% endmacro %}

--- a/macros/min_by.sql
+++ b/macros/min_by.sql
@@ -1,0 +1,37 @@
+{% macro min_by(value, order_col) %}
+    {{ return(adapter.dispatch('min_by', 'kwwhat')(value, order_col)) }}
+{% endmacro %}
+
+{% macro default__min_by(value, order_col) %}
+    {{ exceptions.raise_compiler_error(
+        "min_by not implemented for adapter " ~ target.type
+    ) }}
+{% endmacro %}
+
+{% macro snowflake__min_by(value, order_col) %}
+    min_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro duckdb__min_by(value, order_col) %}
+    min_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro bigquery__min_by(value, order_col) %}
+    any_value({{ value }} having min {{ order_col }})
+{% endmacro %}
+
+{% macro postgres__min_by(value, order_col) %}
+    (array_agg({{ value }} order by {{ order_col }}))[1]
+{% endmacro %}
+
+{% macro redshift__min_by(value, order_col) %}
+    (array_agg({{ value }} order by {{ order_col }}))[1]
+{% endmacro %}
+
+{% macro trino__min_by(value, order_col) %}
+    min_by({{ value }}, {{ order_col }})
+{% endmacro %}
+
+{% macro presto__min_by(value, order_col) %}
+    min_by({{ value }}, {{ order_col }})
+{% endmacro %}

--- a/macros/min_by.sql
+++ b/macros/min_by.sql
@@ -3,16 +3,6 @@
 {% endmacro %}
 
 {% macro default__min_by(value, order_col) %}
-    {{ exceptions.raise_compiler_error(
-        "min_by not implemented for adapter " ~ target.type
-    ) }}
-{% endmacro %}
-
-{% macro snowflake__min_by(value, order_col) %}
-    min_by({{ value }}, {{ order_col }})
-{% endmacro %}
-
-{% macro duckdb__min_by(value, order_col) %}
     min_by({{ value }}, {{ order_col }})
 {% endmacro %}
 
@@ -24,14 +14,11 @@
     (array_agg({{ value }} order by {{ order_col }}))[1]
 {% endmacro %}
 
+# Dont forget to cast from varchar if needed  #
 {% macro redshift__min_by(value, order_col) %}
-    (array_agg({{ value }} order by {{ order_col }}))[1]
-{% endmacro %}
-
-{% macro trino__min_by(value, order_col) %}
-    min_by({{ value }}, {{ order_col }})
-{% endmacro %}
-
-{% macro presto__min_by(value, order_col) %}
-    min_by({{ value }}, {{ order_col }})
+    SPLIT_PART(
+        LISTAGG({{ value }}::varchar, CHR(1)) WITHIN GROUP (ORDER BY {{ order_col }} ASC),
+        CHR(1),
+        1
+    )
 {% endmacro %}

--- a/models/intermediate/int_driver_aggregates.sql
+++ b/models/intermediate/int_driver_aggregates.sql
@@ -2,8 +2,7 @@
   config(
     materialized='incremental',
     unique_key='id_tag',
-    incremental_strategy='merge',
-    cluster_by='last_seen_ts'
+    incremental_strategy='merge'
   )
 }}
 
@@ -14,7 +13,10 @@
 {%- endif -%}
 
 with incremental_date_range as (
-    {{ incremental_date_range(from_timestamp_caps=from_ts_caps) }}
+    {{ incremental_date_range(
+        from_timestamp_caps=from_ts_caps,
+        buffer_minutes=30
+        ) }}
 ),
 
 attempts as (
@@ -41,8 +43,8 @@ new_aggs as (
         id_tag,
         min(charge_attempt_start_ts) as first_seen_ts,
         max(charge_attempt_start_ts) as last_seen_ts,
-        min_by(id_tag_status, charge_attempt_start_ts) as first_authorization_status,
-        max_by(id_tag_status, charge_attempt_start_ts) as latest_authorization_status,
+        {{ min_by('id_tag_status', 'charge_attempt_start_ts') }} as first_authorization_status,
+        {{ max_by('id_tag_status', 'charge_attempt_start_ts') }} as latest_authorization_status,
         max(incremental_ts) as incremental_ts
     from attempts
     where id_tag is not null

--- a/models/intermediate/int_driver_aggregates.sql
+++ b/models/intermediate/int_driver_aggregates.sql
@@ -65,12 +65,20 @@ new_aggs as (
 ),
 
 final as (
-{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+{% if is_incremental() %}
 
     select
         n.id_tag,
-        coalesce(b.first_seen_ts, n.first_seen_ts) as first_seen_ts,
-        n.last_seen_ts as last_seen_ts,
+        case
+            when b.first_seen_ts is null or n.first_seen_ts <= b.first_seen_ts
+                then n.first_seen_ts
+            else b.first_seen_ts
+        end as first_seen_ts,
+        case
+            when b.last_seen_ts is null or n.last_seen_ts >= b.last_seen_ts
+                then n.last_seen_ts
+            else b.last_seen_ts
+        end as last_seen_ts,
         case
             when b.first_seen_ts is null or n.first_seen_ts <= b.first_seen_ts
                 then n.first_authorization_status

--- a/models/intermediate/int_driver_aggregates.sql
+++ b/models/intermediate/int_driver_aggregates.sql
@@ -69,8 +69,8 @@ final as (
 
     select
         n.id_tag,
-        least(n.first_seen_ts, coalesce(b.first_seen_ts, n.first_seen_ts)) as first_seen_ts,
-        greatest(n.last_seen_ts, coalesce(b.last_seen_ts, n.last_seen_ts)) as last_seen_ts,
+        coalesce(b.first_seen_ts, n.first_seen_ts) as first_seen_ts,
+        n.last_seen_ts as last_seen_ts,
         case
             when b.first_seen_ts is null or n.first_seen_ts <= b.first_seen_ts
                 then n.first_authorization_status
@@ -81,7 +81,7 @@ final as (
                 then n.latest_authorization_status
             else b.latest_authorization_status
         end as latest_authorization_status,
-        greatest(n.incremental_ts, coalesce(b.incremental_ts, n.incremental_ts)) as incremental_ts
+        n.incremental_ts as incremental_ts
     from new_aggs n
     left join {{ this }} b on n.id_tag = b.id_tag
 

--- a/models/intermediate/int_driver_aggregates.sql
+++ b/models/intermediate/int_driver_aggregates.sql
@@ -1,0 +1,100 @@
+{{
+  config(
+    materialized='incremental',
+    unique_key='id_tag',
+    incremental_strategy='merge',
+    cluster_by='last_seen_ts'
+  )
+}}
+
+{%- if is_incremental() -%}
+    {%- set from_ts_caps = ["(select max(incremental_ts) from " ~ this ~ ")"] -%}
+{%- else -%}
+    {%- set from_ts_caps = ["cast('" ~ var('start_processing_date') ~ "' as " ~ dbt.type_timestamp() ~ ")"] -%}
+{%- endif -%}
+
+with incremental_date_range as (
+    {{ incremental_date_range(from_timestamp_caps=from_ts_caps) }}
+),
+
+attempts as (
+    select
+        case
+            when att.id_tags is not null and {{ array_size('att.id_tags') }} > 0
+                then cast({{ array_first('att.id_tags') }} as {{ dbt.type_string() }})
+            else null
+        end as id_tag,
+        case
+            when att.id_tag_statuses is not null and {{ array_size('att.id_tag_statuses') }} > 0
+                then cast({{ array_first('att.id_tag_statuses') }} as {{ dbt.type_string() }})
+            else null
+        end as id_tag_status,
+        att.charge_attempt_start_ts,
+        att.incremental_ts
+    from {{ ref('fact_charge_attempts') }} att
+    where att.incremental_ts > (select from_timestamp from incremental_date_range)
+        and att.incremental_ts <= (select to_timestamp from incremental_date_range)
+),
+
+new_aggs as (
+    select
+        id_tag,
+        min(charge_attempt_start_ts) as first_seen_ts,
+        max(charge_attempt_start_ts) as last_seen_ts,
+        min_by(id_tag_status, charge_attempt_start_ts) as first_authorization_status,
+        max_by(id_tag_status, charge_attempt_start_ts) as latest_authorization_status,
+        max(incremental_ts) as incremental_ts
+    from attempts
+    where id_tag is not null
+    group by id_tag
+
+    union all
+
+    select
+        '__UNKNOWN__' as id_tag,
+        min(charge_attempt_start_ts) as first_seen_ts,
+        max(charge_attempt_start_ts) as last_seen_ts,
+        cast(null as {{ dbt.type_string() }}) as first_authorization_status,
+        cast(null as {{ dbt.type_string() }}) as latest_authorization_status,
+        max(incremental_ts) as incremental_ts
+    from attempts
+    where id_tag is null
+    having count(*) > 0
+),
+
+final as (
+{% if is_incremental() and adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) %}
+
+    select
+        n.id_tag,
+        least(n.first_seen_ts, coalesce(b.first_seen_ts, n.first_seen_ts)) as first_seen_ts,
+        greatest(n.last_seen_ts, coalesce(b.last_seen_ts, n.last_seen_ts)) as last_seen_ts,
+        case
+            when b.first_seen_ts is null or n.first_seen_ts <= b.first_seen_ts
+                then n.first_authorization_status
+            else b.first_authorization_status
+        end as first_authorization_status,
+        case
+            when b.last_seen_ts is null or n.last_seen_ts >= b.last_seen_ts
+                then n.latest_authorization_status
+            else b.latest_authorization_status
+        end as latest_authorization_status,
+        greatest(n.incremental_ts, coalesce(b.incremental_ts, n.incremental_ts)) as incremental_ts
+    from new_aggs n
+    left join {{ this }} b on n.id_tag = b.id_tag
+
+{% else %}
+
+    select * from new_aggs
+
+{% endif %}
+)
+
+select
+    id_tag,
+    first_seen_ts,
+    last_seen_ts,
+    first_authorization_status,
+    latest_authorization_status,
+    incremental_ts
+from final

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -205,6 +205,45 @@ models:
               - connector_id
               - ingested_ts
 
+  - name: int_driver_aggregates
+    description: "Incremental per-driver aggregation over fact_charge_attempts. Maintains running first/last timestamps and authorization statuses per id_tag. Also tracks unauthorized attempts (null id_tag) under the sentinel id_tag '__UNKNOWN__'. Consumed by dim_drivers so that dim_drivers never scans fact_charge_attempts directly."
+    columns:
+      - name: id_tag
+        description: "RFID tag string observed in OCPP messages. Natural key; null id_tag rows (unauthorized attempts) are excluded."
+        tests:
+          - not_null
+          - unique
+      - name: first_seen_ts
+        description: "Earliest charge_attempt_start_ts for this driver. Updated via least() on each incremental merge to handle late-arriving events."
+        tests:
+          - not_null
+      - name: last_seen_ts
+        description: "Most recent charge_attempt_start_ts for this driver. Updated via greatest() on each incremental merge."
+        tests:
+          - not_null
+      - name: first_authorization_status
+        description: "Authorization status at the driver's earliest charge attempt. Follows first_seen_ts: updated when a new batch contains an earlier event."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Accepted', 'Blocked', 'Expired', 'Invalid', 'ConcurrentTx']
+      - name: latest_authorization_status
+        description: "Authorization status at the driver's most recent charge attempt. Follows last_seen_ts: updated when a new batch contains a later event."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Accepted', 'Blocked', 'Expired', 'Invalid', 'ConcurrentTx']
+      - name: incremental_ts
+        description: "Largest incremental_ts from fact_charge_attempts processed into this row. Serves as the watermark for the next incremental run."
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "last_seen_ts >= first_seen_ts"
+          config:
+            severity: error
+
   - name: int_meter_values
     description: "Intermediate incremental model that processes transaction-level aggregated meter values. Provides min, max, and average values for each measurand aggregated across the entire transaction. Use for transaction-level analysis."
     columns:

--- a/models/intermediate/unit_tests.yml
+++ b/models/intermediate/unit_tests.yml
@@ -2,6 +2,71 @@ version: 2
 
 unit_tests:
 
+  # ── int_driver_aggregates ───────────────────────────────────────────────────
+
+  - name: test_int_driver_aggregates_late_arriving_event_updates_first_seen
+    description: "A late-arriving event with an earlier charge_attempt_start_ts must overwrite first_seen_ts and first_authorization_status."
+    model: int_driver_aggregates
+    overrides:
+      macros:
+        is_incremental: true
+      vars:
+        start_processing_date: '2025-10-01 00:00:00'
+    given:
+      - input: this
+        format: dict
+        rows:
+          - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 11:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Accepted', latest_authorization_status: 'Blocked', incremental_ts: '2025-10-02 12:00:00'}
+      - input: ref('fact_charge_attempts')
+        format: dict
+        rows:
+          - {id_tags: ['TAG-001'], id_tag_statuses: ['Invalid'], charge_attempt_start_ts: '2025-10-02 09:00:00', incremental_ts: '2025-10-02 13:00:00'}
+    expect:
+      rows:
+        - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 09:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked'}
+
+  - name: test_int_driver_aggregates_new_latest_event_updates_last_seen
+    description: "A new event with a later charge_attempt_start_ts must overwrite last_seen_ts and latest_authorization_status."
+    model: int_driver_aggregates
+    overrides:
+      macros:
+        is_incremental: true
+      vars:
+        start_processing_date: '2025-10-01 00:00:00'
+    given:
+      - input: this
+        format: dict
+        rows:
+          - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 11:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Accepted', latest_authorization_status: 'Accepted', incremental_ts: '2025-10-02 12:00:00'}
+      - input: ref('fact_charge_attempts')
+        format: dict
+        rows:
+          - {id_tags: ['TAG-001'], id_tag_statuses: ['Blocked'], charge_attempt_start_ts: '2025-10-02 14:00:00', incremental_ts: '2025-10-02 15:00:00'}
+    expect:
+      rows:
+        - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 11:00:00', last_seen_ts: '2025-10-02 14:00:00', first_authorization_status: 'Accepted', latest_authorization_status: 'Blocked'}
+
+  - name: test_int_driver_aggregates_unknown_sentinel_accumulates_incremental
+    description: "Null id_tag rows aggregate under __UNKNOWN__ and merge correctly with the existing sentinel on incremental runs."
+    model: int_driver_aggregates
+    overrides:
+      macros:
+        is_incremental: true
+      vars:
+        start_processing_date: '2025-10-01 00:00:00'
+    given:
+      - input: this
+        format: dict
+        rows:
+          - {id_tag: '__UNKNOWN__', first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00', first_authorization_status: null, latest_authorization_status: null, incremental_ts: '2025-10-02 09:00:00'}
+      - input: ref('fact_charge_attempts')
+        format: dict
+        rows:
+          - {id_tags: [], id_tag_statuses: [], charge_attempt_start_ts: '2025-10-02 07:00:00', incremental_ts: '2025-10-02 13:00:00'}
+    expect:
+      rows:
+        - {id_tag: '__UNKNOWN__', first_seen_ts: '2025-10-02 07:00:00', last_seen_ts: '2025-10-02 09:00:00', first_authorization_status: null, latest_authorization_status: null}
+
   # ── int_status_changes ──────────────────────────────────────────────────────
 
   - name: test_status_changes_deduplicates_consecutive_same_status

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -11,22 +11,8 @@ with attempts as (
                 then cast({{ array_first('att.id_tags') }} as {{ dbt.type_string() }})
             else null
         end as id_tag,
-        att.charge_attempt_start_ts,
-        p.location_id
+        att.charge_attempt_start_ts
     from {{ ref('fact_charge_attempts') }} att
-    inner join {{ ref('stg_ports') }} p
-        on att.charge_point_id = p.charge_point_id
-        and att.connector_id = p.connector_id
-),
-
-attempts_ranked as (
-    select
-        *,
-        row_number() over (
-            partition by id_tag is null, id_tag
-            order by charge_attempt_start_ts
-        ) as rn_first_in_group
-    from attempts
 ),
 
 known_drivers as (
@@ -35,9 +21,8 @@ known_drivers as (
         id_tag,
         true as is_known_driver,
         min(charge_attempt_start_ts) as first_seen_ts,
-        max(charge_attempt_start_ts) as last_seen_ts,
-        min(case when rn_first_in_group = 1 then location_id end) as first_seen_location_id
-    from attempts_ranked
+        max(charge_attempt_start_ts) as last_seen_ts
+    from attempts
     where id_tag is not null
     group by id_tag
 ),
@@ -47,12 +32,9 @@ unknown_driver as (
         {{ dbt_utils.generate_surrogate_key(["'UNKNOWN'"]) }} as driver_key,
         'UNKNOWN' as id_tag,
         false as is_known_driver,
-        coalesce(min(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as
-first_seen_ts,
-        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as
-last_seen_ts,
-        min(case when rn_first_in_group = 1 then location_id end) as first_seen_location_id
-    from attempts_ranked
+        coalesce(min(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as first_seen_ts,
+        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as last_seen_ts
+    from attempts
     where id_tag is null
 )
 
@@ -61,8 +43,7 @@ select
     id_tag,
     is_known_driver,
     first_seen_ts,
-    last_seen_ts,
-    first_seen_location_id
+    last_seen_ts
 from known_drivers
 union all
 select
@@ -70,6 +51,5 @@ select
     id_tag,
     is_known_driver,
     first_seen_ts,
-    last_seen_ts,
-    first_seen_location_id
+    last_seen_ts
 from unknown_driver

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    materialized='table',
+    materialized='table'
   )
 }}
 
@@ -11,6 +11,11 @@ with attempts as (
                 then cast({{ array_first('att.id_tags') }} as {{ dbt.type_string() }})
             else null
         end as id_tag,
+        case
+            when att.id_tag_statuses is not null and {{ array_size('att.id_tag_statuses') }} > 0
+                then cast({{ array_first('att.id_tag_statuses') }} as {{ dbt.type_string() }})
+            else null
+        end as id_tag_status,
         att.charge_attempt_start_ts
     from {{ ref('fact_charge_attempts') }} att
 ),
@@ -21,7 +26,9 @@ known_drivers as (
         id_tag,
         true as is_known_driver,
         min(charge_attempt_start_ts) as first_seen_ts,
-        max(charge_attempt_start_ts) as last_seen_ts
+        max(charge_attempt_start_ts) as last_seen_ts,
+        min_by(id_tag_status, charge_attempt_start_ts) as first_authorization_status,
+        max_by(id_tag_status, charge_attempt_start_ts) as latest_authorization_status
     from attempts
     where id_tag is not null
     group by id_tag
@@ -33,7 +40,9 @@ unknown_driver as (
         'UNKNOWN' as id_tag,
         false as is_known_driver,
         coalesce(min(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as first_seen_ts,
-        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as last_seen_ts
+        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as last_seen_ts,
+        cast(null as {{ dbt.type_string() }}) as first_authorization_status,
+        cast(null as {{ dbt.type_string() }}) as latest_authorization_status
     from attempts
     where id_tag is null
 )
@@ -43,7 +52,9 @@ select
     id_tag,
     is_known_driver,
     first_seen_ts,
-    last_seen_ts
+    last_seen_ts,
+    first_authorization_status,
+    latest_authorization_status
 from known_drivers
 union all
 select
@@ -51,5 +62,7 @@ select
     id_tag,
     is_known_driver,
     first_seen_ts,
-    last_seen_ts
+    last_seen_ts,
+    first_authorization_status,
+    latest_authorization_status
 from unknown_driver

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -1,6 +1,75 @@
 {{
   config(
     materialized='table',
-    description='Drivers dimension; Primary source is fact_charge_attempts'
   )
 }}
+
+with attempts as (
+    select
+        case
+            when att.id_tags is not null and {{ array_size('att.id_tags') }} > 0
+                then cast({{ array_first('att.id_tags') }} as {{ dbt.type_string() }})
+            else null
+        end as id_tag,
+        att.charge_attempt_start_ts,
+        p.location_id
+    from {{ ref('fact_charge_attempts') }} att
+    inner join {{ ref('stg_ports') }} p
+        on att.charge_point_id = p.charge_point_id
+        and att.connector_id = p.connector_id
+),
+
+attempts_ranked as (
+    select
+        *,
+        row_number() over (
+            partition by id_tag is null, id_tag
+            order by charge_attempt_start_ts
+        ) as rn_first_in_group
+    from attempts
+),
+
+known_drivers as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['id_tag']) }} as driver_key,
+        id_tag,
+        true as is_known_driver,
+        min(charge_attempt_start_ts) as first_seen_ts,
+        max(charge_attempt_start_ts) as last_seen_ts,
+        min(case when rn_first_in_group = 1 then location_id end) as first_seen_location_id
+    from attempts_ranked
+    where id_tag is not null
+    group by id_tag
+),
+
+unknown_driver as (
+    select
+        {{ dbt_utils.generate_surrogate_key(["'UNKNOWN'"]) }} as driver_key,
+        'UNKNOWN' as id_tag,
+        false as is_known_driver,
+        coalesce(min(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as
+first_seen_ts,
+        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as
+last_seen_ts,
+        min(case when rn_first_in_group = 1 then location_id end) as first_seen_location_id
+    from attempts_ranked
+    where id_tag is null
+)
+
+select
+    driver_key,
+    id_tag,
+    is_known_driver,
+    first_seen_ts,
+    last_seen_ts,
+    first_seen_location_id
+from known_drivers
+union all
+select
+    driver_key,
+    id_tag,
+    is_known_driver,
+    first_seen_ts,
+    last_seen_ts,
+    first_seen_location_id
+from unknown_driver

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -4,20 +4,8 @@
   )
 }}
 
-with attempts as (
-    select
-        case
-            when att.id_tags is not null and {{ array_size('att.id_tags') }} > 0
-                then cast({{ array_first('att.id_tags') }} as {{ dbt.type_string() }})
-            else null
-        end as id_tag,
-        case
-            when att.id_tag_statuses is not null and {{ array_size('att.id_tag_statuses') }} > 0
-                then cast({{ array_first('att.id_tag_statuses') }} as {{ dbt.type_string() }})
-            else null
-        end as id_tag_status,
-        att.charge_attempt_start_ts
-    from {{ ref('fact_charge_attempts') }} att
+with all_driver_aggs as (
+    select * from {{ ref('int_driver_aggregates') }}
 ),
 
 known_drivers as (
@@ -25,13 +13,12 @@ known_drivers as (
         {{ dbt_utils.generate_surrogate_key(['id_tag']) }} as driver_key,
         id_tag,
         true as is_known_driver,
-        min(charge_attempt_start_ts) as first_seen_ts,
-        max(charge_attempt_start_ts) as last_seen_ts,
-        min_by(id_tag_status, charge_attempt_start_ts) as first_authorization_status,
-        max_by(id_tag_status, charge_attempt_start_ts) as latest_authorization_status
-    from attempts
-    where id_tag is not null
-    group by id_tag
+        first_seen_ts,
+        last_seen_ts,
+        first_authorization_status,
+        latest_authorization_status
+    from all_driver_aggs
+    where id_tag != '__UNKNOWN__'
 ),
 
 unknown_driver as (
@@ -39,12 +26,17 @@ unknown_driver as (
         {{ dbt_utils.generate_surrogate_key(["'UNKNOWN'"]) }} as driver_key,
         'UNKNOWN' as id_tag,
         false as is_known_driver,
-        coalesce(min(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as first_seen_ts,
-        coalesce(max(charge_attempt_start_ts), cast('1900-01-01' as {{ dbt.type_timestamp() }})) as last_seen_ts,
+        coalesce(
+            max(case when id_tag = '__UNKNOWN__' then first_seen_ts end),
+            cast('1900-01-01' as {{ dbt.type_timestamp() }})
+        ) as first_seen_ts,
+        coalesce(
+            max(case when id_tag = '__UNKNOWN__' then last_seen_ts end),
+            cast('1900-01-01' as {{ dbt.type_timestamp() }})
+        ) as last_seen_ts,
         cast(null as {{ dbt.type_string() }}) as first_authorization_status,
         cast(null as {{ dbt.type_string() }}) as latest_authorization_status
-    from attempts
-    where id_tag is null
+    from all_driver_aggs
 ),
 
 final as (

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -1,0 +1,6 @@
+{{
+  config(
+    materialized='table',
+    description='Drivers dimension; Primary source is fact_charge_attempts'
+  )
+}}

--- a/models/marts/dim_drivers.sql
+++ b/models/marts/dim_drivers.sql
@@ -45,24 +45,28 @@ unknown_driver as (
         cast(null as {{ dbt.type_string() }}) as latest_authorization_status
     from attempts
     where id_tag is null
+),
+
+final as (
+    select
+        driver_key,
+        id_tag,
+        is_known_driver,
+        first_seen_ts,
+        last_seen_ts,
+        first_authorization_status,
+        latest_authorization_status
+    from known_drivers
+    union all
+    select
+        driver_key,
+        id_tag,
+        is_known_driver,
+        first_seen_ts,
+        last_seen_ts,
+        first_authorization_status,
+        latest_authorization_status
+    from unknown_driver
 )
 
-select
-    driver_key,
-    id_tag,
-    is_known_driver,
-    first_seen_ts,
-    last_seen_ts,
-    first_authorization_status,
-    latest_authorization_status
-from known_drivers
-union all
-select
-    driver_key,
-    id_tag,
-    is_known_driver,
-    first_seen_ts,
-    last_seen_ts,
-    first_authorization_status,
-    latest_authorization_status
-from unknown_driver
+select * from final

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -1,7 +1,6 @@
 {{
   config(
-    materialized='table',
-    description='Port/connector dimension; full refresh from int_ports'
+    materialized='table'
   )
 }}
 

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -32,7 +32,7 @@ select
         'ports.charge_point_id', 
         'ports.port_id', 
         'ports.connector_id'
-        ]) }} as port_sk,
+        ]) }} as port_key,
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -447,6 +447,6 @@ select
     grouping_key,
     {{ dbt.datediff('visit_start_ts', 'visit_end_ts', 'minute') }} as visit_duration_minutes,
     {{ dbt_utils.generate_surrogate_key(['location_id', 'first_charge_point_id', "first_port_id", 'visit_start_ts']) }} as visit_id,
+    {{ dbt_utils.generate_surrogate_key(["coalesce(id_tag, 'UNKNOWN')"]) }} as driver_key,
     (select incremental_ts from incremental) as incremental_ts
 from visits
-

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -209,6 +209,16 @@ models:
           - not_null
       - name: id_tag
         description: "Driver identifier (RFID tag). Null for visits where authorization failed. May be inferred from subsequent authorized attempts within 2 minutes on the same charger."
+      - name: driver_key
+        description: "Foreign key to dim_drivers. Computed as dbt_utils.generate_surrogate_key(coalesce(id_tag, 'UNKNOWN')) so unauthorized visits resolve to the UNKNOWN sentinel."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_drivers')
+                field: driver_key
+              config:
+                severity: warn
       - name: visit_start_ts
         description: "Start timestamp of the first charge attempt in the visit (charge_attempt_start_ts)"
         tests:
@@ -330,7 +340,7 @@ models:
               - connector_id
 
   - name: dim_drivers
-    description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Full refresh from fact_charge_attempts + stg_ports. Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, first location) are derived; lifetime metrics belong in the semantic layer, not on this dim."
+    description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Full refresh from fact_charge_attempts. Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, first location) are derived; lifetime metrics belong in the semantic layer, not on this dim."
     columns:
       - name: driver_key
         description: "Surrogate key for the driver dimension. Deterministic hash of id_tag. The UNKNOWN sentinel uses a stable hash of the literal 'UNKNOWN'."
@@ -357,6 +367,18 @@ models:
         description: "Most recent charge_attempt_start_ts associated with this driver. For the UNKNOWN sentinel: the most recent unauthorized attempt, or '1900-01-01' if none exist yet."
         tests:
           - not_null
+      - name: first_authorization_status
+        description: "Authorization status reported for this driver's earliest charge attempt (from id_tag_statuses array). Null for the UNKNOWN sentinel (no id_tag observed)."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Accepted', 'Blocked', 'Expired', 'Invalid', 'ConcurrentTx']
+      - name: latest_authorization_status
+        description: "Authorization status reported for this driver's most recent charge attempt (from id_tag_statuses array). Null for the UNKNOWN sentinel (no id_tag observed)."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Accepted', 'Blocked', 'Expired', 'Invalid', 'ConcurrentTx']
     tests:
       - dbt_utils.expression_is_true:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -350,8 +350,6 @@ models:
         description: "Most recent charge_attempt_start_ts associated with this driver. For the UNKNOWN sentinel: the most recent unauthorized attempt, or '1900-01-01' if none exist yet."
         tests:
           - not_null
-      - name: first_seen_location_id
-        description: "location_id of the charger where the driver was first seen. Nullable for the UNKNOWN sentinel when no unauthorized attempts exist. Note: drivers are not bound to locations; this is an 'origin' tag, not an identity attribute."
     tests:
       - dbt_utils.expression_is_true:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -286,7 +286,7 @@ models:
   - name: dim_ports
     description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
     columns:
-      - name: port_sk
+      - name: port_key
         description: "Surrogate key for the port/connector dimension"
         tests:
           - not_null

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -322,6 +322,43 @@ models:
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested"
 
+  - name: dim_drivers
+    description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Full refresh from fact_charge_attempts + stg_ports. Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, first location) are derived; lifetime metrics belong in the semantic layer, not on this dim."
+    columns:
+      - name: driver_key
+        description: "Surrogate key for the driver dimension. Deterministic hash of id_tag. The UNKNOWN sentinel uses a stable hash of the literal 'UNKNOWN'."
+        tests:
+          - not_null
+          - unique
+      - name: id_tag
+        description: "Natural key. RFID tag string observed in OCPP messages, or the literal 'UNKNOWN' for the sentinel row aggregating all unauthorized visits."
+        tests:
+          - not_null
+          - unique
+      - name: is_known_driver
+        description: "True for real drivers (id_tag observed in logs). False only for the UNKNOWN sentinel row."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: first_seen_ts
+        description: "Earliest charge_attempt_start_ts associated with this driver. For the UNKNOWN sentinel: the earliest unauthorized attempt, or '1900-01-01' if none exist yet."
+        tests:
+          - not_null
+      - name: last_seen_ts
+        description: "Most recent charge_attempt_start_ts associated with this driver. For the UNKNOWN sentinel: the most recent unauthorized attempt, or '1900-01-01' if none exist yet."
+        tests:
+          - not_null
+      - name: first_seen_location_id
+        description: "location_id of the charger where the driver was first seen. Nullable for the UNKNOWN sentinel when no unauthorized attempts exist. Note: drivers are not bound to locations; this is an 'origin' tag, not an identity attribute."
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "last_seen_ts >= first_seen_ts"
+          config:
+            severity: error
+
   - name: charge_point_span_daily
     description: "One row per charge point per day between commissioned and decommissioned, with minutes the charger was commissioned that day. Used for uptime and availability metrics."
     columns:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -340,7 +340,7 @@ models:
               - connector_id
 
   - name: dim_drivers
-    description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Full refresh from fact_charge_attempts. Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, first location) are derived; lifetime metrics belong in the semantic layer, not on this dim."
+    description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Reads from int_driver_aggregates (never scans fact_charge_attempts directly). Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, authorization status) are derived; lifetime metrics belong in the semantic layer, not on this dim."
     columns:
       - name: driver_key
         description: "Surrogate key for the driver dimension. Deterministic hash of id_tag. The UNKNOWN sentinel uses a stable hash of the literal 'UNKNOWN'."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -284,7 +284,7 @@ models:
         granularity: day
   
   - name: dim_ports
-    description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
+    description: "Port/connector dimension. Grain: one row per (charge_point_id, port_id, connector_id). Full refresh from stg_ports. Type 1 (overwrite on each refresh). Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
     columns:
       - name: port_key
         description: "Surrogate key for the port/connector dimension"
@@ -321,6 +321,13 @@ models:
         description: "Error code from the most recent StatusNotification (e.g., NoError, ConnectorLockFailure)"
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+              - connector_id
 
   - name: dim_drivers
     description: "Driver dimension. Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus a single UNKNOWN sentinel row for unauthorized visits. Full refresh from fact_charge_attempts + stg_ports. Type 1 (overwrite on each refresh). Behavioral attributes (first/last seen, first location) are derived; lifetime metrics belong in the semantic layer, not on this dim."

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -1,6 +1,25 @@
 version: 2
 
 unit_tests:
+  # ── dim_drivers ─────────────────────────────────────────────────────────────
+
+  - name: test_dim_drivers_first_latest_authorization_status
+    description: "first_authorization_status is the status at the earliest charge_attempt_start_ts; latest_authorization_status is the status at the most recent one."
+    model: dim_drivers
+    given:
+      - input: ref('fact_charge_attempts')
+        format: dict
+        rows:
+          - {id_tags: ['TAG-001'], id_tag_statuses: ['Invalid'],  charge_attempt_start_ts: '2025-10-02 10:00:00'}
+          - {id_tags: ['TAG-001'], id_tag_statuses: ['Accepted'], charge_attempt_start_ts: '2025-10-02 11:00:00'}
+          - {id_tags: ['TAG-001'], id_tag_statuses: ['Blocked'],  charge_attempt_start_ts: '2025-10-02 12:00:00'}
+    expect:
+      rows:
+        - {id_tag: 'TAG-001', is_known_driver: true,  first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked'}
+        - {id_tag: 'UNKNOWN', is_known_driver: false, first_authorization_status: null,      latest_authorization_status: null}
+
+  # ── fact_visits ─────────────────────────────────────────────────────────────
+
   - name: test_authorized_visits_15min_apart_same_location
     description: "Two authorized attempts on the same charger 15 minutes apart should result in one visit (gap from stop_ts to start_ts < 30 min)"
     model: fact_visits

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -14,8 +14,8 @@ unit_tests:
           - {id_tag: '__UNKNOWN__', first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00', first_authorization_status: null, latest_authorization_status: null, incremental_ts: '2025-10-02 09:00:00'}
     expect:
       rows:
-        - {id_tag: 'TAG-001', is_known_driver: true,  first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked'}
-        - {id_tag: 'UNKNOWN', is_known_driver: false, first_authorization_status: null,      latest_authorization_status: null, first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00'}
+        - {id_tag: 'TAG-001', is_known_driver: true,  first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked', first_seen_ts: '2025-10-02 10:00:00', last_seen_ts: '2025-10-02 12:00:00'}
+        - {id_tag: 'UNKNOWN', is_known_driver: false, first_authorization_status: null,      latest_authorization_status: null,    first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00'}
 
   - name: test_dim_drivers_unknown_sentinel_fallback_when_no_unauthorized_attempts
     description: "When no __UNKNOWN__ row exists in int_driver_aggregates yet, the UNKNOWN sentinel gets first_seen_ts and last_seen_ts of 1900-01-01."
@@ -27,7 +27,7 @@ unit_tests:
           - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 10:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Accepted', latest_authorization_status: 'Accepted', incremental_ts: '2025-10-02 12:00:00'}
     expect:
       rows:
-        - {id_tag: 'TAG-001', is_known_driver: true}
+        - {id_tag: 'TAG-001', is_known_driver: true, first_seen_ts: '2025-10-02 10:00:00', last_seen_ts: '2025-10-02 12:00:00'}
         - {id_tag: 'UNKNOWN', is_known_driver: false, first_seen_ts: '1900-01-01 00:00:00', last_seen_ts: '1900-01-01 00:00:00'}
 
   # ── fact_visits ─────────────────────────────────────────────────────────────

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -3,20 +3,32 @@ version: 2
 unit_tests:
   # ── dim_drivers ─────────────────────────────────────────────────────────────
 
-  - name: test_dim_drivers_first_latest_authorization_status
-    description: "first_authorization_status is the status at the earliest charge_attempt_start_ts; latest_authorization_status is the status at the most recent one."
+  - name: test_dim_drivers_assembles_known_and_unknown_rows
+    description: "dim_drivers passes through known drivers from int_driver_aggregates and maps the __UNKNOWN__ sentinel to the UNKNOWN row."
     model: dim_drivers
     given:
-      - input: ref('fact_charge_attempts')
+      - input: ref('int_driver_aggregates')
         format: dict
         rows:
-          - {id_tags: ['TAG-001'], id_tag_statuses: ['Invalid'],  charge_attempt_start_ts: '2025-10-02 10:00:00'}
-          - {id_tags: ['TAG-001'], id_tag_statuses: ['Accepted'], charge_attempt_start_ts: '2025-10-02 11:00:00'}
-          - {id_tags: ['TAG-001'], id_tag_statuses: ['Blocked'],  charge_attempt_start_ts: '2025-10-02 12:00:00'}
+          - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 10:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked', incremental_ts: '2025-10-02 12:00:00'}
+          - {id_tag: '__UNKNOWN__', first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00', first_authorization_status: null, latest_authorization_status: null, incremental_ts: '2025-10-02 09:00:00'}
     expect:
       rows:
         - {id_tag: 'TAG-001', is_known_driver: true,  first_authorization_status: 'Invalid', latest_authorization_status: 'Blocked'}
-        - {id_tag: 'UNKNOWN', is_known_driver: false, first_authorization_status: null,      latest_authorization_status: null}
+        - {id_tag: 'UNKNOWN', is_known_driver: false, first_authorization_status: null,      latest_authorization_status: null, first_seen_ts: '2025-10-02 08:00:00', last_seen_ts: '2025-10-02 09:00:00'}
+
+  - name: test_dim_drivers_unknown_sentinel_fallback_when_no_unauthorized_attempts
+    description: "When no __UNKNOWN__ row exists in int_driver_aggregates yet, the UNKNOWN sentinel gets first_seen_ts and last_seen_ts of 1900-01-01."
+    model: dim_drivers
+    given:
+      - input: ref('int_driver_aggregates')
+        format: dict
+        rows:
+          - {id_tag: 'TAG-001', first_seen_ts: '2025-10-02 10:00:00', last_seen_ts: '2025-10-02 12:00:00', first_authorization_status: 'Accepted', latest_authorization_status: 'Accepted', incremental_ts: '2025-10-02 12:00:00'}
+    expect:
+      rows:
+        - {id_tag: 'TAG-001', is_known_driver: true}
+        - {id_tag: 'UNKNOWN', is_known_driver: false, first_seen_ts: '1900-01-01 00:00:00', last_seen_ts: '1900-01-01 00:00:00'}
 
   # ── fact_visits ─────────────────────────────────────────────────────────────
 

--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -13,6 +13,9 @@ semantic_models:
       - name: charge_attempt
         type: foreign
         expr: last_charge_attempt_id
+      - name: driver
+        type: foreign
+        expr: driver_key
     dimensions:
       - name: visit_end_ts
         type: time
@@ -164,6 +167,42 @@ semantic_models:
         description: "Percentage of attempts with transactions that were successful"
         agg: average
         expr: case when transaction_id is not null then cast(is_successful as integer) else null end
+
+  - name: drivers
+    description: "Driver dimension. One row per RFID id_tag observed in OCPP charge attempts, plus an UNKNOWN sentinel for unauthorized visits."
+    model: ref('dim_drivers')
+    defaults:
+      agg_time_dimension: first_seen_ts
+    entities:
+      - name: driver
+        type: primary
+        expr: driver_key
+    dimensions:
+      - name: id_tag
+        type: categorical
+      - name: is_known_driver
+        type: categorical
+      - name: first_authorization_status
+        type: categorical
+      - name: latest_authorization_status
+        type: categorical
+      - name: first_seen_ts
+        type: time
+        type_params:
+          time_granularity: day
+      - name: last_seen_ts
+        type: time
+        type_params:
+          time_granularity: day
+    measures:
+      - name: drivers_count
+        description: "Total number of distinct drivers (includes the UNKNOWN sentinel)"
+        agg: count
+        expr: driver_key
+      - name: known_drivers_count
+        description: "Number of drivers with a real id_tag (excludes UNKNOWN sentinel)"
+        agg: sum_boolean
+        expr: is_known_driver
 
   - name: uptime
     description: "Port-level daily uptime: fraction of commissioned minutes not lost to outages"


### PR DESCRIPTION
Implements issue #91: a Kimball conformed driver dimension derived from fact_charge_attempts.

New model: models/marts/dim_drivers.sql

- Grain: one row per distinct RFID id_tag observed in OCPP charge attempts, plus one 'UNKNOWN' sentinel row for unauthorized visits.
- Materialization: table, Type 1 (full refresh).
- Source: fact_charge_attempts only (keeps DAG shallow — dim_drivers runs in parallel with fact_visits).
- Columns:
  - driver_key — surrogate key, dbt_utils.generate_surrogate_key(['id_tag'])
  - id_tag — natural key (first element of id_tags array, or 'UNKNOWN')
  - is_known_driver — false only for the UNKNOWN sentinel
  - first_seen_ts / last_seen_ts — min/max charge_attempt_start_ts
  - first_authorization_status / latest_authorization_status — status at earliest/latest attempt, via Snowflake min_by/max_by on id_tag_statuses[0]

Wiring downstream: models/marts/fact_visits.sql

- New driver_key column computed in-model as dbt_utils.generate_surrogate_key(['coalesce(id_tag, ''UNKNOWN'')']) — no join required. Unauthorized visits resolve to the UNKNOWN sentinel.

Tests: models/marts/marts.yml

- On dim_drivers:
  - driver_key: not_null + unique
  - id_tag: not_null + unique
  - is_known_driver: not_null + accepted_values [true, false]
  - first_seen_ts / last_seen_ts: not_null
  - first_authorization_status / latest_authorization_status: accepted_values (Accepted, Blocked, Expired, Invalid, ConcurrentTx) - Like this for now. Not sure about actual strings here.
  - Model-level: dbt_utils.expression_is_true enforcing last_seen_ts >= first_seen_ts
- On fact_visits:
  - New driver_key column doc + not_null test
  - Warn-severity relationships test: fact_visits.driver_key → dim_drivers.driver_key

Unit test: models/marts/unit_tests.yml

- test_dim_drivers_first_latest_authorization_status — feeds three attempts for the same id_tag (Invalid → Accepted → Blocked) and asserts the first/latest pick logic plus the UNKNOWN sentinel row.

Semantic layer: models/semantic/semantic_models.yml

- New drivers semantic model: driver as primary entity (expr: driver_key), categorical dims (id_tag, is_known_driver, first_authorization_status, latest_authorization_status), time dims (first_seen_ts, last_seen_ts), measures (drivers_count, known_drivers_count).
- driver added as foreign entity on the visits semantic model.

Deliberate deviations from issue #91

- Sentinel literal is 'UNKNOWN' (issue suggested '__UNKNOWN__') — matches fact_visits.driver_key derivation.
- first_seen_location_id dropped (commit 54900b1) — unnecessary overhead; location context already lives on fact_visits / fact_charge_attempts.

Closes #91 
Closes #94 