### PR TITLE
int_ports

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -109,8 +109,15 @@ docker compose down -v
 
 Tests live in `chat-bi/tests/` and run against the live chat server.
 
+**Step 1 — open a shell inside the running chat-bi container:**
+
 ```bash
 docker exec -it $(docker ps -q --filter "publish=5005") bash -lc "cd /app/kwwhat && exec bash"
+```
+
+**Step 2 — inside the container, run the test suite:**
+
+```bash
 nao test -m anthropic:claude-sonnet-4-6
 ```
 

--- a/models/intermediate/int_ports.sql
+++ b/models/intermediate/int_ports.sql
@@ -1,0 +1,16 @@
+{{
+  config(
+    materialized='table',
+    description='Materialized snapshot of stg_ports. Breaks the live RAW catalog dependency for downstream views and incremental models.'
+  )
+}}
+
+select
+    charge_point_id,
+    location_id,
+    port_id,
+    connector_id,
+    connector_type,
+    commissioned_ts,
+    decommissioned_ts
+from {{ ref('stg_ports') }}

--- a/models/intermediate/int_status_changes.sql
+++ b/models/intermediate/int_status_changes.sql
@@ -74,7 +74,7 @@ with incremental_date_range as (
             conf.ingested_timestamp as confirmation_ingested_ts
             
         from status_notification_events req
-        left join {{ ref("stg_ports") }} p
+        left join {{ ref("int_ports") }} p
             on req.charge_point_id = p.charge_point_id
             and req.connector_id = p.connector_id
         left join ocpp_logs conf

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -274,3 +274,28 @@ models:
             expression: "min_value <= avg_value and avg_value <= max_value"
           config:
             severity: error
+
+  - name: int_ports
+    description: "Materialized snapshot of stg_ports. Breaks the live RAW catalog dependency for downstream views and incremental models. Grain: one row per charge_point_id + port_id + connector_id."
+    columns:
+      - name: charge_point_id
+        description: "Charger identifier"
+      - name: location_id
+        description: "Location identifier where the charge point is located"
+      - name: port_id
+        description: "Port identifier within the charge point"
+      - name: connector_id
+        description: "Connector identifier within the port"
+      - name: connector_type
+        description: "Type of connector (e.g., CCS, NACS)"
+      - name: commissioned_ts
+        description: "Timestamp when the charge point was commissioned (null if not commissioned yet)"
+      - name: decommissioned_ts
+        description: "Timestamp when the charge point was decommissioned (null if still active)"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+              - connector_id

--- a/models/intermediate/outages/int_faulted_outages.sql
+++ b/models/intermediate/outages/int_faulted_outages.sql
@@ -60,7 +60,7 @@ ports_count as (
         charge_point_id,
         port_id,
         count(distinct connector_id) as connector_count
-    from {{ ref("stg_ports") }}
+    from {{ ref("int_ports") }}
     group by 1, 2
 ),
 

--- a/models/intermediate/outages/int_offline_outages.sql
+++ b/models/intermediate/outages/int_offline_outages.sql
@@ -34,7 +34,7 @@ charger_context as (
             coalesce(max(decommissioned_ts), (select to_timestamp from incremental_date_range)),
             (select to_timestamp from incremental_date_range)
         ) as monitoring_end_ts
-    from {{ ref("stg_ports") }}
+    from {{ ref("int_ports") }}
     where commissioned_ts is not null
         and commissioned_ts < (select to_timestamp from incremental_date_range)
         and (decommissioned_ts is null or decommissioned_ts > (select from_timestamp from incremental_date_range))

--- a/models/intermediate/unit_tests.yml
+++ b/models/intermediate/unit_tests.yml
@@ -22,7 +22,7 @@ unit_tests:
           select cast('2025-10-01 10:00:00' as timestamp), 'CH-001', 'StatusNotification', '2', 'UID-001', '{"connectorId": 1, "errorCode": "NoError", "status": "Available"}'
           union all
           select cast('2025-10-01 10:30:00' as timestamp), 'CH-001', 'StatusNotification', '2', 'UID-002', '{"connectorId": 1, "errorCode": "NoError", "status": "Available"}'
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -49,7 +49,7 @@ unit_tests:
           select cast('2025-10-01 10:05:00' as timestamp), 'CH-001', 'StatusNotification', '2', 'UID-002', '{"connectorId": 1, "errorCode": "NoError", "status": "Preparing"}'
           union all
           select cast('2025-10-01 10:10:00' as timestamp), 'CH-001', 'StatusNotification', '2', 'UID-003', '{"connectorId": 1, "errorCode": "NoError", "status": "Charging"}'
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -94,7 +94,7 @@ unit_tests:
         format: sql
         rows: |
           select cast('2025-10-01 10:05:00' as timestamp) as ingested_timestamp, 'CH-001' as charge_point_id, 'StatusNotification' as action, '2' as message_type_id, 'UID-001' as unique_id, '{"connectorId": 1, "errorCode": "NoError", "status": "Preparing"}' as payload
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -120,7 +120,7 @@ unit_tests:
           select 'CH-001' as charge_point_id, 'PORT-001' as port_id, '1' as connector_id, cast('2025-10-01 10:00:00' as timestamp) as ingested_ts, 'Faulted'   as status, cast(null as string) as next_status, cast('2025-10-01 11:00:00' as timestamp) as next_ingested_ts, cast('2025-10-01 12:00:00' as timestamp) as incremental_ts
           union all
           select 'CH-001', 'PORT-001', '2', cast('2025-10-01 10:00:00' as timestamp), 'Available', cast(null as string), cast(null as timestamp), cast('2025-10-01 12:00:00' as timestamp)
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -144,7 +144,7 @@ unit_tests:
           select 'CH-001' as charge_point_id, 'PORT-001' as port_id, '1' as connector_id, cast('2025-10-01 10:00:00' as timestamp) as ingested_ts, 'Faulted' as status, cast(null as string) as next_status, cast('2025-10-01 11:00:00' as timestamp) as next_ingested_ts, cast('2025-10-01 12:00:00' as timestamp) as incremental_ts
           union all
           select 'CH-001', 'PORT-001', '2', cast('2025-10-01 10:00:00' as timestamp), 'Faulted', cast(null as string), cast('2025-10-01 11:00:00' as timestamp), cast('2025-10-01 12:00:00' as timestamp)
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -169,7 +169,7 @@ unit_tests:
           select 'CH-001' as charge_point_id, 'PORT-001' as port_id, '1' as connector_id, cast('2025-10-01 10:00:00' as timestamp) as ingested_ts, 'Faulted' as status, cast(null as string) as next_status, cast('2025-10-01 11:00:00' as timestamp) as next_ingested_ts, cast('2025-10-01 12:00:00' as timestamp) as incremental_ts
           union all
           select 'CH-001', 'PORT-001', '1', cast('2025-10-01 11:00:00' as timestamp), 'Faulted', cast(null as string), cast('2025-10-01 12:00:00' as timestamp), cast('2025-10-01 12:00:00' as timestamp)
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -194,7 +194,7 @@ unit_tests:
           select cast('2025-10-01 10:00:00' as timestamp) as ingested_timestamp, 'CH-001' as charge_point_id, 'Heartbeat' as action, '2' as message_type_id, 'UID-001' as unique_id, '{}' as payload
           union all
           select cast('2025-10-01 11:30:00' as timestamp), 'CH-001', 'Heartbeat', '2', 'UID-002', '{}'
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-10-01 09:59:00' as timestamp) as commissioned_ts, cast('2025-10-01 11:30:00' as timestamp) as decommissioned_ts
@@ -217,7 +217,7 @@ unit_tests:
           select cast('2025-10-01 10:00:00' as timestamp) as ingested_timestamp, 'CH-001' as charge_point_id, 'Heartbeat' as action, '2' as message_type_id, 'UID-001' as unique_id, '{}' as payload
           union all
           select cast('2025-10-01 10:04:00' as timestamp), 'CH-001', 'Heartbeat', '2', 'UID-002', '{}'
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-10-01 09:59:00' as timestamp) as commissioned_ts, cast('2025-10-01 10:04:00' as timestamp) as decommissioned_ts
@@ -237,7 +237,7 @@ unit_tests:
         format: sql
         rows: |
           select cast('2025-10-01 13:00:00' as timestamp) as ingested_timestamp, 'CH-002' as charge_point_id, 'Heartbeat' as action, '2' as message_type_id, 'UID-999' as unique_id, '{}' as payload
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-10-01 10:00:00' as timestamp) as commissioned_ts, cast('2025-10-01 12:00:00' as timestamp) as decommissioned_ts
@@ -268,7 +268,7 @@ unit_tests:
         format: sql
         rows: |
           select cast('2025-10-01 10:30:00' as timestamp) as ingested_timestamp, 'CH-001' as charge_point_id, 'Heartbeat' as action, '2' as message_type_id, 'UID-001' as unique_id, '{}' as payload
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-10-01 09:00:00' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts

--- a/models/marts/charge_point_span_daily.sql
+++ b/models/marts/charge_point_span_daily.sql
@@ -10,7 +10,7 @@ with ports as (
         charge_point_id,
         min(commissioned_ts) as commissioned_ts,
         max(decommissioned_ts) as decommissioned_ts
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
     where commissioned_ts is not null
     group by charge_point_id
 ),

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Port/connector dimension; full refresh from stg_ports'
+    description='Port/connector dimension; full refresh from int_ports'
   )
 }}
 

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -14,7 +14,7 @@ with ports as (
         connector_type,
         commissioned_ts,
         decommissioned_ts
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
 ),
 
 latest_status as (

--- a/models/marts/fact_downtime_daily.sql
+++ b/models/marts/fact_downtime_daily.sql
@@ -23,7 +23,7 @@ ports as (
         port_id,
         commissioned_ts,
         decommissioned_ts
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
 ),
 
 -- Get faulted outages first to filter offline outages

--- a/models/marts/fact_uptime.sql
+++ b/models/marts/fact_uptime.sql
@@ -7,7 +7,7 @@
 
 with ports as (
     select distinct charge_point_id, port_id
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
 ),
 
 span_port_days as (

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -43,7 +43,7 @@ charge_attempts_with_location as (
             else null
         end as id_tag
     from {{ ref("fact_charge_attempts") }} att
-    inner join {{ ref("stg_ports") }} p
+    inner join {{ ref("int_ports") }} p
         on att.charge_point_id = p.charge_point_id
         and att.connector_id = p.connector_id
     where att.incremental_ts > (select from_timestamp from incremental_date_range)

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -64,7 +64,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -134,7 +134,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -205,7 +205,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:40:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -276,7 +276,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -345,7 +345,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -415,7 +415,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 12:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -486,7 +486,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -556,7 +556,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 13:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -681,7 +681,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts              
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -749,7 +749,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -816,7 +816,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:02:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -884,7 +884,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 12:05:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -1264,7 +1264,7 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, cast('2025-10-01 10:30:00' as timestamp) as from_ts, cast('2025-10-01 12:30:00' as timestamp) as to_ts, 120 as duration_minutes, cast('2025-10-01 12:30:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -1293,7 +1293,7 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, cast('2025-10-01 22:00:00' as timestamp) as from_ts, cast('2025-10-02 04:00:00' as timestamp) as to_ts, 360 as duration_minutes, cast('2025-10-02 12:00:00' as timestamp) as incremental_ts
-      - input: ref('stg_ports')
+      - input: ref('int_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts


### PR DESCRIPTION
Introducing missing layer int_ports to fix ChatBI and failing tests. The idea is that top marts view should not have a dependency of raw model.

Why int_ports fixes the Catalog "RAW" does not exist error

The root cause was a transitive view chain that reached all the way back to the raw source database at query time.

fact_uptime is a view. When DuckDB executes a query against it, it resolves the full view definition on the fly — including all  upstream views in the dependency chain. One of those upstream views is stg_ports, which was compiled by dbt into a DuckDB VIEW whose stored SQL literally reads FROM RAW.SEED.ports. RAW is the catalog alias for raw.duckdb, attached by dbt during the build via  profiles.yml. It exists during dbt run, but nao connects to analytics.duckdb directly — without that attachment — so DuckDB's binder  fails the moment it tries to walk the chain.

The chain before this fix:
  fact_uptime (view)
    └── stg_ports (view)
          └── RAW.SEED.ports  ← binder error here


After:
<img width="711" height="134" alt="Screenshot 2026-05-29 at 2 51 04 PM" src="https://github.com/user-attachments/assets/24727f67-ed78-4126-8f9f-faca3b60cff4" />


