### PR TITLE
dim_locations

### DIFF
--- a/models/intermediate/int_ports.sql
+++ b/models/intermediate/int_ports.sql
@@ -14,9 +14,6 @@ with ports as (
         connector_type,
         commissioned_ts,
         decommissioned_ts,
-        count(*) over (partition by charge_point_id) as connector_count,
-        count(distinct port_id) over (partition by charge_point_id) as port_count,
-        count(distinct charge_point_id) over (partition by location_id) as charge_point_count
     from {{ ref('stg_ports') }}
 )
 
@@ -28,8 +25,4 @@ select
     connector_type,
     commissioned_ts,
     decommissioned_ts,
-    connector_count,
-    port_count,
-    charge_point_count,
-    connector_count > 1 as has_multiple_connectors
 from ports

--- a/models/intermediate/int_ports.sql
+++ b/models/intermediate/int_ports.sql
@@ -5,6 +5,21 @@
   )
 }}
 
+with ports as (
+    select
+        charge_point_id,
+        location_id,
+        port_id,
+        connector_id,
+        connector_type,
+        commissioned_ts,
+        decommissioned_ts,
+        count(*) over (partition by charge_point_id) as connector_count,
+        count(distinct port_id) over (partition by charge_point_id) as port_count,
+        count(distinct charge_point_id) over (partition by location_id) as charge_point_count
+    from {{ ref('stg_ports') }}
+)
+
 select
     charge_point_id,
     location_id,
@@ -12,5 +27,9 @@ select
     connector_id,
     connector_type,
     commissioned_ts,
-    decommissioned_ts
-from {{ ref('stg_ports') }}
+    decommissioned_ts,
+    connector_count,
+    port_count,
+    charge_point_count,
+    connector_count > 1 as has_multiple_connectors
+from ports

--- a/models/marts/dim_charge_points.sql
+++ b/models/marts/dim_charge_points.sql
@@ -6,14 +6,18 @@
 }}
 
 with ports as (
-    select distinct
+    select
         charge_point_id,
         location_id,
         commissioned_ts,
         decommissioned_ts,
-        port_count,
-        connector_count,
+        count(distinct port_id) as port_count
     from {{ ref('int_ports') }}
+    group by
+        charge_point_id,
+        location_id,
+        commissioned_ts,
+        decommissioned_ts
 )
 
 select
@@ -22,7 +26,6 @@ select
     ports.location_id,
     ports.commissioned_ts,
     ports.decommissioned_ts,
-    ports.port_count,
-    ports.connector_count,
     ports.decommissioned_ts is null as is_active,
+    port_count,
 from ports

--- a/models/marts/dim_charge_points.sql
+++ b/models/marts/dim_charge_points.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    materialized='table',
+    description='Charge point dimension; one row per charge point.'
+  )
+}}
+
+with ports as (
+    select distinct
+        charge_point_id,
+        location_id,
+        commissioned_ts,
+        decommissioned_ts,
+        port_count,
+        connector_count,
+    from {{ ref('int_ports') }}
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['ports.charge_point_id']) }} as charge_point_key,
+    ports.charge_point_id,
+    ports.location_id,
+    ports.commissioned_ts,
+    ports.decommissioned_ts,
+    ports.port_count,
+    ports.connector_count,
+    ports.decommissioned_ts is null as is_active,
+from ports

--- a/models/marts/dim_connectors.sql
+++ b/models/marts/dim_connectors.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Port/connector dimension; full refresh from stg_ports'
+    description='Connector dimension; full refresh from int_ports'
   )
 }}
 
@@ -12,8 +12,6 @@ with ports as (
         port_id,
         connector_id,
         connector_type,
-        commissioned_ts,
-        decommissioned_ts
     from {{ ref('int_ports') }}
 ),
 
@@ -23,7 +21,7 @@ latest_status as (
         connector_id,
         latest_status,
         latest_error_code,
-        latest_status_ts
+        latest_status_ts,
     from {{ ref('int_connector_latest_status') }}
 )
 
@@ -38,11 +36,9 @@ select
     ports.port_id,
     ports.connector_id,
     ports.connector_type,
-    ports.commissioned_ts,
-    ports.decommissioned_ts,
     latest_status.latest_status,
     latest_status.latest_error_code,
-    latest_status.latest_status_ts
+    latest_status.latest_status_ts,
 from ports
 left join latest_status
     on ports.charge_point_id = latest_status.charge_point_id

--- a/models/marts/dim_connectors.sql
+++ b/models/marts/dim_connectors.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Port/connector dimension; full refresh from int_ports'
+    description='Port/connector dimension; full refresh from stg_ports'
   )
 }}
 
@@ -30,8 +30,9 @@ latest_status as (
 select
     {{ dbt_utils.generate_surrogate_key([
         'ports.charge_point_id', 
-        'ports.port_id'
-        ]) }} as port_key,
+        'ports.port_id', 
+        'ports.connector_id'
+        ]) }} as connector_key,
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -7,7 +7,7 @@
 with ports as (
     select
         location_id
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
 ),
 
 locations as (

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -1,22 +1,17 @@
 {{
   config(
-    materialized='table'
+    materialized='table',
+    description="Conformed location dimension. One row per distinct charging location. SCD Type 1."
   )
 }}
 
-with ports as (
-    select
-        location_id
-    from {{ ref('int_ports') }}
-),
-
-locations as (
+with locations as (
     select distinct
         location_id
-    from ports
+    from {{ ref('int_ports') }}
 )
 
 select
     {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
-    location_id,
+    location_id
 from locations

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -7,11 +7,11 @@
 
 with locations as (
     select distinct
-        location_id
+        location_id,
     from {{ ref('int_ports') }}
 )
 
 select
     {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
-    location_id
+    location_id,
 from locations

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -1,0 +1,22 @@
+{{
+  config(
+    materialized='table'
+  )
+}}
+
+with ports as (
+    select
+        location_id
+    from {{ ref('stg_ports') }}
+),
+
+locations as (
+    select distinct
+        location_id
+    from ports
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
+    location_id,
+from locations

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -6,25 +6,11 @@
 }}
 
 with ports as (
-    select
-        charge_point_id,
-        location_id,
+    select distinct
+        charge_point_id, 
         port_id,
-        connector_id,
-        connector_type,
-        commissioned_ts,
-        decommissioned_ts
+        location_id,
     from {{ ref('int_ports') }}
-),
-
-latest_status as (
-    select
-        charge_point_id,
-        connector_id,
-        latest_status,
-        latest_error_code,
-        latest_status_ts
-    from {{ ref('int_connector_latest_status') }}
 )
 
 select
@@ -35,14 +21,4 @@ select
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,
-    ports.connector_id,
-    ports.connector_type,
-    ports.commissioned_ts,
-    ports.decommissioned_ts,
-    latest_status.latest_status,
-    latest_status.latest_error_code,
-    latest_status.latest_status_ts
 from ports
-left join latest_status
-    on ports.charge_point_id = latest_status.charge_point_id
-    and ports.connector_id = latest_status.connector_id

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -10,7 +10,12 @@ with ports as (
         charge_point_id, 
         port_id,
         location_id,
+        count(connector_id) as connector_count,
     from {{ ref('int_ports') }}
+    group by
+        charge_point_id, 
+        port_id, 
+        location_id
 )
 
 select
@@ -21,4 +26,5 @@ select
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,
+    ports.connector_count,
 from ports

--- a/models/marts/fact_downtime_daily.sql
+++ b/models/marts/fact_downtime_daily.sql
@@ -20,10 +20,8 @@ with incremental_date_range as (
 ports as (
     select
         charge_point_id,
-        port_id,
-        commissioned_ts,
-        decommissioned_ts
-    from {{ ref('int_ports') }}
+        port_id
+    from {{ ref('dim_ports') }}
 ),
 
 -- Get faulted outages first to filter offline outages

--- a/models/marts/fact_location_capacity.sql
+++ b/models/marts/fact_location_capacity.sql
@@ -1,0 +1,33 @@
+{{
+  config(
+    materialized='table',
+    description="One row per location. Physical capacity counts derived from int_ports. Full refresh — counts are overwritten when ports are commissioned or decommissioned."
+  )
+}}
+
+with ports as (
+    select
+        location_id,
+        charge_point_id,
+        port_id,
+        connector_id
+    from {{ ref('int_ports') }}
+),
+
+capacity as (
+    select
+        location_id,
+        count(distinct charge_point_id) as charge_point_count,
+        count(distinct charge_point_id || '|' || cast(port_id as varchar)) as port_count,
+        count(distinct charge_point_id || '|' || cast(port_id as varchar) || '|' || cast(connector_id as varchar)) as connector_count
+    from ports
+    group by location_id
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
+    location_id,
+    charge_point_count,
+    port_count,
+    connector_count
+from capacity

--- a/models/marts/fact_uptime.sql
+++ b/models/marts/fact_uptime.sql
@@ -6,8 +6,10 @@
 }}
 
 with ports as (
-    select distinct charge_point_id, port_id
-    from {{ ref('int_ports') }}
+    select
+        charge_point_id,
+        port_id
+    from {{ ref('dim_ports') }}
 ),
 
 span_port_days as (

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -429,6 +429,7 @@ new_visits as (
 {% endif %}
 
 select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
     location_id,
     charge_point_ids,
     id_tag,

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -43,7 +43,7 @@ charge_attempts_with_location as (
             else null
         end as id_tag
     from {{ ref("fact_charge_attempts") }} att
-    inner join {{ ref("int_ports") }} p
+    inner join {{ ref("dim_connectors") }} p
         on att.charge_point_id = p.charge_point_id
         and att.connector_id = p.connector_id
     where att.incremental_ts > (select from_timestamp from incremental_date_range)

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -203,6 +203,13 @@ models:
         tests:
           - not_null
           - unique
+      - name: location_key
+        description: "Foreign key to dim_locations."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_locations')
+              field: location_key
       - name: location_id
         description: "Location identifier where the visit occurred"
         tests:
@@ -323,7 +330,7 @@ models:
         description: "Timestamp when the most recent status was ingested"
 
   - name: dim_locations
-    description: "Location dimension. One row per distinct location. Grain: one row per location_id."
+    description: "Conformed location dimension. One row per distinct charging location. SCD Type 1."
     columns:
       - name: location_key
         description: "Surrogate key for the location dimension, generated from location_id."
@@ -335,6 +342,44 @@ models:
         tests:
           - not_null
           - unique
+
+  - name: fact_location_capacity
+    description: "Physical capacity counts per location. One row per location. Full refresh — counts are overwritten when ports are commissioned or decommissioned. Join to dim_locations on location_key for site-level analysis."
+    columns:
+      - name: location_key
+        description: "Surrogate key matching dim_locations.location_key."
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              to: ref('dim_locations')
+              field: location_key
+      - name: location_id
+        description: "Natural key. Location identifier sourced from int_ports."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_count
+        description: "Number of distinct charge points (devices) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: port_count
+        description: "Number of distinct ports (charge_point + port combinations) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: connector_count
+        description: "Number of distinct connectors (charge_point + port + connector combinations) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
 
   - name: charge_point_span_daily
     description: "One row per charge point per day between commissioned and decommissioned, with minutes the charger was commissioned that day. Used for uptime and availability metrics."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -286,7 +286,7 @@ models:
   - name: dim_ports
     description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
     columns:
-      - name: port_sk
+      - name: port_key
         description: "Surrogate key for the port/connector dimension"
         tests:
           - not_null

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -323,6 +323,12 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: port_count
+        description: "Number of ports on this charge point."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 1
 
   - name: dim_ports
     description: "Port dimension. One row per (charge_point_id, port_id). Use for faulted outages, port-level uptime, port inventory, operational analysis."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -290,44 +290,129 @@ models:
         description: "Date at day granularity; used as time spine standard granularity column"
         granularity: day
   
-  - name: dim_ports
-    description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
+  - name: dim_charge_points
+    description: "Charge point dimension. One row per charge point. Use for offline outages, charger-level uptime and availability, charger inventory, and visit attribution at charger level."
     columns:
-      - name: port_key
-        description: "Surrogate key for the port/connector dimension"
+      - name: charge_point_key
+        description: "Surrogate key for the charge point, generated from charge_point_id."
         tests:
           - not_null
           - unique
       - name: charge_point_id
-        description: "Charger identifier"
+        description: "Natural key. Unique identifier for the charge point."
+        tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: "Location where this charge point is installed."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_locations')
+              field: location_id
+      - name: commissioned_ts
+        description: "Timestamp when the charge point was commissioned."
+        tests:
+          - not_null
+      - name: decommissioned_ts
+        description: "Timestamp when the charge point was decommissioned. Null if still active."
+      - name: port_count
+        description: "Number of ports on this charge point."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: connector_count
+        description: "Number of connectors on this charge point across all ports."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: is_active
+        description: "True if the charge point has not been decommissioned."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+  - name: dim_ports
+    description: "Port dimension. One row per (charge_point_id, port_id). Use for faulted outages, port-level uptime, port inventory, operational analysis."
+    columns:
+      - name: port_key
+        description: "Surrogate key for the port, generated from charge_point_id and port_id."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_id
+        description: "Charge point this port belongs to."
         tests:
           - not_null
       - name: location_id
-        description: "Location identifier where the charger is located"
+        description: "Location where this port is installed."
+        tests:
+          - not_null
       - name: port_id
-        description: "Port identifier within the charger"
+        description: "Port identifier within the charge point."
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+
+  - name: dim_connectors
+    description: "Connector dimension. One row per (charge_point_id, port_id, connector_id). Use for connector-type analysis, current inventory, and connector-specific operational reporting if needed. Finest-grain hardware dimension."
+    columns:
+      - name: connector_key
+        description: "Surrogate key for the connector, generated from charge_point_id, port_id, and connector_id."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_id
+        description: "Charge point this connector belongs to."
+        tests:
+          - not_null
+      - name: location_id
+        description: "Location where this connector is installed."
+        tests:
+          - not_null
+      - name: port_id
+        description: "Port this connector belongs to."
         tests:
           - not_null
       - name: connector_id
-        description: "Connector identifier within the port"
+        description: "Connector identifier within the port."
         tests:
           - not_null
       - name: connector_type
-        description: "Type of connector (e.g., CCS, NACS)"
-      - name: commissioned_ts
-        description: "Timestamp when the charger was commissioned (null if not commissioned yet)"
-      - name: decommissioned_ts
-        description: "Timestamp when the charger was decommissioned (null if still active)"
+        description: "Plug standard for this connector (e.g. CCS, NACS)."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['CCS', 'NACS', 'CHAdeMO', 'Type1', 'Type2']
       - name: latest_status
-        description: "Most recent OCPP status reported by this connector (null if no status has been received)"
+        description: "Most recent OCPP status reported by this connector. Null if no StatusNotification has been received yet."
         tests:
           - accepted_values:
               arguments:
                 values: ['Available', 'Preparing', 'Charging', 'SuspendedEVSE', 'SuspendedEV', 'Finishing', 'Reserved', 'Unavailable', 'Faulted']
       - name: latest_error_code
-        description: "Error code from the most recent StatusNotification (e.g., NoError, ConnectorLockFailure)"
+        description: "Error code from the most recent StatusNotification (e.g. NoError, ConnectorLockFailure)."
       - name: latest_status_ts
-        description: "Timestamp when the most recent status was ingested"
+        description: "Timestamp when the most recent status was ingested."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+              - connector_id
 
   - name: dim_locations
     description: "Conformed location dimension. One row per distinct charging location. SCD Type 1."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -316,20 +316,6 @@ models:
           - not_null
       - name: decommissioned_ts
         description: "Timestamp when the charge point was decommissioned. Null if still active."
-      - name: port_count
-        description: "Number of ports on this charge point."
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
-      - name: connector_count
-        description: "Number of connectors on this charge point across all ports."
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
       - name: is_active
         description: "True if the charge point has not been decommissioned."
         tests:
@@ -358,6 +344,12 @@ models:
         description: "Port identifier within the charge point."
         tests:
           - not_null
+      - name: connectors_count
+        description: "Number of connectors on this port."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 1
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -322,6 +322,20 @@ models:
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested"
 
+  - name: dim_locations
+    description: "Location dimension. One row per distinct location. Grain: one row per location_id."
+    columns:
+      - name: location_key
+        description: "Surrogate key for the location dimension, generated from location_id."
+        tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: "Natural key. Location identifier sourced from stg_ports."
+        tests:
+          - not_null
+          - unique
+
   - name: charge_point_span_daily
     description: "One row per charge point per day between commissioned and decommissioned, with minutes the charger was commissioned that day. Used for uptime and availability metrics."
     columns:

--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -1,6 +1,50 @@
 version: 2
 
 semantic_models:
+  - name: charge_points
+    description: "Charge point dimension. Use to slice metrics by charger lifecycle attributes (active/decommissioned, port count, connector count)."
+    model: ref('dim_charge_points')
+    entities:
+      - name: charge_point
+        type: primary
+        expr: charge_point_id
+    dimensions:
+      - name: is_active
+        type: categorical
+        description: "True if the charge point has not been decommissioned."
+      - name: location_id
+        type: categorical
+
+  - name: ports
+    description: "Port dimension. Use to slice uptime and downtime metrics by port."
+    model: ref('dim_ports')
+    entities:
+      - name: port
+        type: primary
+        expr: port_key
+    dimensions:
+      - name: charge_point_id
+        type: categorical
+      - name: location_id
+        type: categorical
+
+  - name: connectors
+    description: "Connector dimension. Use to slice metrics by connector type or current status."
+    model: ref('dim_connectors')
+    entities:
+      - name: connector
+        type: primary
+        expr: connector_key
+    dimensions:
+      - name: connector_type
+        type: categorical
+      - name: latest_status
+        type: categorical
+      - name: charge_point_id
+        type: categorical
+      - name: location_id
+        type: categorical
+
   - name: visits
     description: ""
     model: ref('fact_visits')
@@ -13,6 +57,9 @@ semantic_models:
       - name: charge_attempt
         type: foreign
         expr: last_charge_attempt_id
+      - name: location
+        type: foreign
+        expr: location_key
     dimensions:
       - name: visit_end_ts
         type: time
@@ -104,6 +151,9 @@ semantic_models:
       - name: charge_attempt
         type: primary
         expr: charge_attempt_id
+      - name: charge_point
+        type: foreign
+        expr: charge_point_id
     dimensions:
       - name: charge_attempt_start_ts
         type: time
@@ -174,6 +224,9 @@ semantic_models:
       - name: uptime_record
         type: primary
         expr: uptime_id
+      - name: charge_point
+        type: foreign
+        expr: charge_point_id
     dimensions:
       - name: date_id
         type: time

--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -189,6 +189,18 @@ semantic_models:
         agg: average
         expr: uptime
 
+  - name: locations
+    description: "Location dimension. One row per distinct location observed in port data."
+    model: ref('dim_locations')
+    # No defaults.agg_time_dimension: this is an attribute-only dimension with no time column or measures.
+    entities:
+      - name: location
+        type: primary
+        expr: location_key
+    dimensions:
+      - name: location_id
+        type: categorical
+
 metrics:
   - name: total_visits
     description: "Total number of charging visits"


### PR DESCRIPTION
Summary

Adds a new dim_locations Kimball-style dimension to the marts layer. This unblocks the companion issue that will wire location_key as a foreign key across all five fact tables. Location is now a first-class dimension with a stable surrogate key, consistent with the existing dim_ports / dim_drivers / dim_dates pattern.

Why

Every fact table currently embeds location_id as a raw natural key with no canonical dimension behind it. This violates the project's Kimball-aligned modeling pattern and makes location-level slicing in dashboards and the semantic layer fragile. The initial dimension is intentionally attribute-sparse — only location_key and location_id — because no other location metadata exists in the source data yet.

Changes

New file
- models/marts/dim_locations.sql — table materialization, two-CTE structure (ports → locations), surrogate key generated via dbt_utils.generate_surrogate_key(['location_id']). Grain: one row per distinct location_id. Source: stg_ports.

Updated files
- models/marts/marts.yml — new dim_locations block with model-level description and column-level docs. Tests: not_null + unique on both location_key and location_id.
- models/semantic/semantic_models.yml — new locations semantic model pointing to ref('dim_locations'), primary entity location keyed on location_key, categorical dimension location_id, no measures. Includes a comment documenting why defaults.agg_time_dimension is deliberately omitted (attribute-only dimension, no time column).

Out of scope (companion issue)

- Wiring location_key as a foreign key in fact_visits, fact_charge_attempts, fact_uptime, etc.
- Enrichment attributes (name, address, region) — no source data available yet.

QA verdict

All acceptance criteria pass. The agg_time_dimension omission is now documented inline.

Definition of done status

- Model created ✓
- Tests defined ✓
- Docs added ✓
- Semantic layer updated ✓

Closes #95 

---

UPD:
Builds the hardware dimension layer and rewires facts off intermediate models

The project had no proper dimension models for charge points, ports, or connectors. Facts were joining directly to int_ports, which is the wrong layer and was causing silent fan-out bugs. This PR introduces dim_charge_points, corrects dim_ports to port grain, renames the old broken dim_ports to dim_connectors, and rewires all three affected facts to join the marts layer instead. Semantic models for all three new dimensions are also wired in.


What changed

New model: dim_charge_points
- One row per charge point. Natural key: charge_point_id. Surrogate: charge_point_key.
- Carries commissioned_ts, decommissioned_ts, port_count, connector_count, is_active.
- Fixes: wrong surrogate key name (port_key) and syntax error present on the branch.

Corrected model: dim_ports
- Now at port grain: one row per (charge_point_id, port_id).
- commissioned_ts/decommissioned_ts removed -- charge point attributes, not port attributes. They now live only in dim_charge_points.

New model: dim_connectors (was the broken dim_ports)
- One row per (charge_point_id, port_id, connector_id).
- Joins int_ports to int_connector_latest_status for latest_status, latest_error_code, latest_status_ts.
- connector_type stays here -- it is a connector attribute.

Facts rewired
- fact_downtime_daily -- ports CTE sourced int_ports without DISTINCT, producing connector fan-out before the offline outage join. Now sources dim_ports.
- fact_uptime -- ports CTE used an ad-hoc SELECT DISTINCT on int_ports (correct result, wrong layer). Now sources dim_ports.
- fact_visits -- was joining int_ports to resolve location_id and port_id. Now joins dim_connectors.

Tests added
- dim_charge_points: surrogate key unique+not_null; charge_point_id unique+not_null; location_id relationship to dim_locations; port_count/connector_count range >= 1; is_active accept
- dim_ports: surrogate key unique+not_null; composite grain test on (charge_point_id, port_id).
- dim_connectors: surrogate key unique+not_null; composnt_id, port_id, connector_id); connector_type andlatest_status accepted_values.

Semantic layer
- New semantic models: charge_points, ports, connectors
- charge_point FK entity added to charge_attempts and uptime (joined on charge_point_id).
- location FK entity added to visits -- location_key wad as an entity, making it invisible to MetricFlow.

---
Why                                                                                                                                          
Grain correctness is the core issue. int_ports is connector-grain. Any CTE selecting from it without DISTINCT on a higher-grain key fans out silently. fact_downtime_daily had exactly this bug. Then every fact -- it's dimension models at the correctgrain.


Intermediate models are not for direct fact joins. Pulling int_ports into fact_visits couples two marts to the same intermediate, making grain changes fragile. Facts should join dims.


Attribute assignment follows grain. commissioned_ts/decally across every connector row in int_ports. Carryingthem into dim_ports or dim_connectors implies a port or connector can be independently commissioned -- which isn't modeled here. They belong in dim_charge_points only.


The old dim_ports was connector-grain in everything butbuilt on (charge_point_id, port_id, connector_id), itselected connector_id and connector_type, and joined to int_connector_latest_status. Renaming it dim_connectors makes vocabulary match grain before any downstream consumer can trust it.
