### PR TITLE
Feature/dim-locations

### DIFF
--- a/demo/chat-bi/tests/decommissioned_ports_check.yml
+++ b/demo/chat-bi/tests/decommissioned_ports_check.yml
@@ -2,5 +2,6 @@ name: decommissioned_ports_check
 prompt: "How many ports are currently decommissioned?"
 sql: |
   SELECT COUNT(*) AS decommissioned_ports
-  FROM analytics.ANALYTICS.dim_ports
-  WHERE decommissioned_ts IS NOT NULL
+  FROM analytics.ANALYTICS.dim_charge_points cp
+  JOIN analytics.ANALYTICS.dim_ports p ON cp.charge_point_id = p.charge_point_id
+  WHERE cp.decommissioned_ts IS NOT NULL

--- a/demo/dbt/entrypoint.sh
+++ b/demo/dbt/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Installing dbt packages..."
 dbt deps --log-path /tmp/dbt-logs
 
 echo "Running dbt run (staging → intermediate → marts)..."
-dbt run --target duckdb --full-refresh --log-path /tmp/dbt-logs
+dbt run --target duckdb --log-path /tmp/dbt-logs
 
 echo "Running dbt tests (failures reported but do not block startup)..."
 dbt test --target duckdb --log-path /tmp/dbt-logs --exclude "test_type:unit" || echo "Some tests failed — see logs."

--- a/demo/dbt/entrypoint.sh
+++ b/demo/dbt/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Installing dbt packages..."
 dbt deps --log-path /tmp/dbt-logs
 
 echo "Running dbt run (staging → intermediate → marts)..."
-dbt run --target duckdb --log-path /tmp/dbt-logs
+dbt run --target duckdb --full-refresh --log-path /tmp/dbt-logs
 
 echo "Running dbt tests (failures reported but do not block startup)..."
 dbt test --target duckdb --log-path /tmp/dbt-logs --exclude "test_type:unit" || echo "Some tests failed — see logs."

--- a/models/intermediate/int_ports.sql
+++ b/models/intermediate/int_ports.sql
@@ -14,9 +14,6 @@ with ports as (
         connector_type,
         commissioned_ts,
         decommissioned_ts,
-        count(*) over (partition by charge_point_id) as connector_count,
-        count(distinct port_id) over (partition by charge_point_id) as port_count,
-        count(distinct charge_point_id) over (partition by location_id) as charge_point_count
     from {{ ref('stg_ports') }}
 )
 
@@ -28,8 +25,4 @@ select
     connector_type,
     commissioned_ts,
     decommissioned_ts,
-    connector_count,
-    port_count,
-    charge_point_count,
-    connector_count > 1 as has_multiple_connectors
 from ports

--- a/models/intermediate/int_ports.sql
+++ b/models/intermediate/int_ports.sql
@@ -5,6 +5,21 @@
   )
 }}
 
+with ports as (
+    select
+        charge_point_id,
+        location_id,
+        port_id,
+        connector_id,
+        connector_type,
+        commissioned_ts,
+        decommissioned_ts,
+        count(*) over (partition by charge_point_id) as connector_count,
+        count(distinct port_id) over (partition by charge_point_id) as port_count,
+        count(distinct charge_point_id) over (partition by location_id) as charge_point_count
+    from {{ ref('stg_ports') }}
+)
+
 select
     charge_point_id,
     location_id,
@@ -12,5 +27,9 @@ select
     connector_id,
     connector_type,
     commissioned_ts,
-    decommissioned_ts
-from {{ ref('stg_ports') }}
+    decommissioned_ts,
+    connector_count,
+    port_count,
+    charge_point_count,
+    connector_count > 1 as has_multiple_connectors
+from ports

--- a/models/intermediate/intermediate.yml
+++ b/models/intermediate/intermediate.yml
@@ -6,32 +6,32 @@ models:
     columns:
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Identifier for the connector"
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Identifier for the port"
-        tests:
+        data_tests:
           - not_null
       - name: latest_status
         description: "Most recent OCPP status for this connector"
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: ['Available', 'Preparing', 'Charging', 'SuspendedEVSE', 'SuspendedEV', 'Finishing', 'Reserved', 'Unavailable', 'Faulted']
       - name: latest_error_code
         description: "Error code from the most recent StatusNotification"
-        tests:
+        data_tests:
           - not_null
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested"
-        tests:
+        data_tests:
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -44,30 +44,30 @@ models:
     columns:
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: unique_id
         description: "Unique identifier for the OCPP message"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Identifier for the connector"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_ts
         description: "Timestamp when the status notification was ingested"
-        tests:
+        data_tests:
           - not_null
       - name: status
         description: "Current status from the notification"
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: ['Available', 'Preparing', 'Charging', 'SuspendedEVSE', 'SuspendedEV', 'Finishing', 'Reserved', 'Unavailable', 'Faulted']
       - name: error_code
         description: "Error code from the status notification payload (NoError if no error to report)"
-        tests:
+        data_tests:
           - not_null        
       - name: payload
         description: "Original payload from the status notification"
@@ -81,7 +81,7 @@ models:
         description: "Timestamp of the next status notification for the same charge point and connector (null for last status)"
       - name: confirmation_ingested_ts
         description: "Timestamp when the confirmation was ingested"
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -104,25 +104,25 @@ models:
     columns:
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Identifier for the charging connector"
-        tests:
+        data_tests:
           - not_null
       - name: unique_id
         description: "Unique identifier for the status change that triggered this charge attempt"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_ts
         description: "Timestamp when the StatusNotification with status 'Preparing' was ingested (start of charge attempt)"
-        tests:
+        data_tests:
           - not_null
       - name: previous_status
         description: "Status before changing to 'Preparing'"
       - name: status
         description: "Current status (should be 'Preparing')"
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -141,11 +141,11 @@ models:
         description: "Array of error codes from StatusNotification messages"
       - name: _unique_transaction_count
         description: "Count of unique transaction IDs for this charge attempt (should be 0 or 1)"
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: [0, 1]
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -158,23 +158,23 @@ models:
     columns:
       - name: transaction_id
         description: "Unique identifier for the transaction from OCPP StartTransaction/StopTransaction messages"
-        tests:
+        data_tests:
           - not_null
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Connector ID for this transaction"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_ts
         description: "Earliest timestamp when any OCPP event for this transaction was ingested"
-        tests:
+        data_tests:
           - not_null
       - name: transaction_start_ts
         description: "Timestamp when the transaction started (from StartTransaction message)"
-        tests:
+        data_tests:
           - not_null
       - name: transaction_stop_ts
         description: "Timestamp when the transaction stopped (from StopTransaction message)"
@@ -193,11 +193,11 @@ models:
       - name: error_codes
         description: "Array of error codes from StatusNotification events that occurred during the transaction"
       - name: _unique_connectors_count
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: [1]
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -210,55 +210,55 @@ models:
     columns:
       - name: charge_point_id
         description: "Unique identifier for the charging point"
-        tests:
+        data_tests:
           - not_null
       - name: transaction_id
         description: "Unique identifier for the charging transaction"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Unique identifier for the connector within the charging point"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_ts
         description: "Timestamp when transaction was ingested into the system"
-        tests:
+        data_tests:
           - not_null
       - name: measurand
         description: "Type of measurement (e.g., Energy.Active.Import.Register, Voltage, Current.Import)"
-        tests:
+        data_tests:
           - not_null
       - name: unit
         description: "Unit of measurement (e.g., Wh, V, A, W)"
-        tests:
+        data_tests:
           - not_null
       - name: phase
         description: "Electrical phase (e.g., L1, L2, L3) or null for single-phase measurements"
       - name: first_measurement_ts
         description: "Meter timestamp of the first measurement for the transaction"
-        tests:
+        data_tests:
           - not_null
       - name: last_measurement_ts
         description: "Meter timestamp of the last measurement for the transaction"
-        tests:
+        data_tests:
           - not_null
       - name: min_value
         description: "Minimum value recorded for the transaction"
-        tests:
+        data_tests:
           - not_null
       - name: max_value
         description: "Maximum value recorded for the transaction"
-        tests:
+        data_tests:
           - not_null
       - name: avg_value
         description: "Average value for the transaction"
-        tests:
+        data_tests:
           - not_null
       - name: _count
         description: "Total number of measurements for the transaction"
-        tests:
+        data_tests:
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -292,7 +292,7 @@ models:
         description: "Timestamp when the charge point was commissioned (null if not commissioned yet)"
       - name: decommissioned_ts
         description: "Timestamp when the charge point was decommissioned (null if still active)"
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:

--- a/models/marts/dim_charge_points.sql
+++ b/models/marts/dim_charge_points.sql
@@ -6,14 +6,18 @@
 }}
 
 with ports as (
-    select distinct
+    select
         charge_point_id,
         location_id,
         commissioned_ts,
         decommissioned_ts,
-        port_count,
-        connector_count,
+        count(distinct port_id) as port_count
     from {{ ref('int_ports') }}
+    group by
+        charge_point_id,
+        location_id,
+        commissioned_ts,
+        decommissioned_ts
 )
 
 select
@@ -22,7 +26,6 @@ select
     ports.location_id,
     ports.commissioned_ts,
     ports.decommissioned_ts,
-    ports.port_count,
-    ports.connector_count,
     ports.decommissioned_ts is null as is_active,
+    port_count,
 from ports

--- a/models/marts/dim_charge_points.sql
+++ b/models/marts/dim_charge_points.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    materialized='table',
+    description='Charge point dimension; one row per charge point.'
+  )
+}}
+
+with ports as (
+    select distinct
+        charge_point_id,
+        location_id,
+        commissioned_ts,
+        decommissioned_ts,
+        port_count,
+        connector_count,
+    from {{ ref('int_ports') }}
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['ports.charge_point_id']) }} as charge_point_key,
+    ports.charge_point_id,
+    ports.location_id,
+    ports.commissioned_ts,
+    ports.decommissioned_ts,
+    ports.port_count,
+    ports.connector_count,
+    ports.decommissioned_ts is null as is_active,
+from ports

--- a/models/marts/dim_connectors.sql
+++ b/models/marts/dim_connectors.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Port/connector dimension; full refresh from stg_ports'
+    description='Connector dimension; full refresh from int_ports'
   )
 }}
 
@@ -12,8 +12,6 @@ with ports as (
         port_id,
         connector_id,
         connector_type,
-        commissioned_ts,
-        decommissioned_ts
     from {{ ref('int_ports') }}
 ),
 
@@ -23,7 +21,7 @@ latest_status as (
         connector_id,
         latest_status,
         latest_error_code,
-        latest_status_ts
+        latest_status_ts,
     from {{ ref('int_connector_latest_status') }}
 )
 
@@ -38,11 +36,9 @@ select
     ports.port_id,
     ports.connector_id,
     ports.connector_type,
-    ports.commissioned_ts,
-    ports.decommissioned_ts,
     latest_status.latest_status,
     latest_status.latest_error_code,
-    latest_status.latest_status_ts
+    latest_status.latest_status_ts,
 from ports
 left join latest_status
     on ports.charge_point_id = latest_status.charge_point_id

--- a/models/marts/dim_connectors.sql
+++ b/models/marts/dim_connectors.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Port/connector dimension; full refresh from int_ports'
+    description='Port/connector dimension; full refresh from stg_ports'
   )
 }}
 
@@ -30,8 +30,9 @@ latest_status as (
 select
     {{ dbt_utils.generate_surrogate_key([
         'ports.charge_point_id', 
-        'ports.port_id'
-        ]) }} as port_key,
+        'ports.port_id', 
+        'ports.connector_id'
+        ]) }} as connector_key,
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -7,7 +7,7 @@
 with ports as (
     select
         location_id
-    from {{ ref('stg_ports') }}
+    from {{ ref('int_ports') }}
 ),
 
 locations as (

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -1,22 +1,17 @@
 {{
   config(
-    materialized='table'
+    materialized='table',
+    description="Conformed location dimension. One row per distinct charging location. SCD Type 1."
   )
 }}
 
-with ports as (
-    select
-        location_id
-    from {{ ref('int_ports') }}
-),
-
-locations as (
+with locations as (
     select distinct
         location_id
-    from ports
+    from {{ ref('int_ports') }}
 )
 
 select
     {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
-    location_id,
+    location_id
 from locations

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -7,11 +7,11 @@
 
 with locations as (
     select distinct
-        location_id
+        location_id,
     from {{ ref('int_ports') }}
 )
 
 select
     {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
-    location_id
+    location_id,
 from locations

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -1,0 +1,22 @@
+{{
+  config(
+    materialized='table'
+  )
+}}
+
+with ports as (
+    select
+        location_id
+    from {{ ref('stg_ports') }}
+),
+
+locations as (
+    select distinct
+        location_id
+    from ports
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
+    location_id,
+from locations

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -6,25 +6,11 @@
 }}
 
 with ports as (
-    select
-        charge_point_id,
-        location_id,
+    select distinct
+        charge_point_id, 
         port_id,
-        connector_id,
-        connector_type,
-        commissioned_ts,
-        decommissioned_ts
+        location_id,
     from {{ ref('int_ports') }}
-),
-
-latest_status as (
-    select
-        charge_point_id,
-        connector_id,
-        latest_status,
-        latest_error_code,
-        latest_status_ts
-    from {{ ref('int_connector_latest_status') }}
 )
 
 select
@@ -35,14 +21,4 @@ select
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,
-    ports.connector_id,
-    ports.connector_type,
-    ports.commissioned_ts,
-    ports.decommissioned_ts,
-    latest_status.latest_status,
-    latest_status.latest_error_code,
-    latest_status.latest_status_ts
 from ports
-left join latest_status
-    on ports.charge_point_id = latest_status.charge_point_id
-    and ports.connector_id = latest_status.connector_id

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -10,7 +10,12 @@ with ports as (
         charge_point_id, 
         port_id,
         location_id,
+        count(connector_id) as connector_count,
     from {{ ref('int_ports') }}
+    group by
+        charge_point_id, 
+        port_id, 
+        location_id
 )
 
 select
@@ -21,4 +26,5 @@ select
     ports.charge_point_id,
     ports.location_id,
     ports.port_id,
+    ports.connector_count,
 from ports

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -7,17 +7,15 @@
 
 with ports as (
     select distinct
-        charge_point_id,
+        charge_point_id, 
         port_id,
         location_id,
-        decommissioned_ts,
         count(connector_id) as connector_count,
     from {{ ref('int_ports') }}
     group by
-        charge_point_id,
-        port_id,
-        location_id,
-        decommissioned_ts
+        charge_point_id, 
+        port_id, 
+        location_id
 )
 
 select
@@ -29,6 +27,4 @@ select
     ports.location_id,
     ports.port_id,
     ports.connector_count,
-    ports.decommissioned_ts,
-    ports.decommissioned_ts is null as is_active,
 from ports

--- a/models/marts/dim_ports.sql
+++ b/models/marts/dim_ports.sql
@@ -7,15 +7,17 @@
 
 with ports as (
     select distinct
-        charge_point_id, 
+        charge_point_id,
         port_id,
         location_id,
+        decommissioned_ts,
         count(connector_id) as connector_count,
     from {{ ref('int_ports') }}
     group by
-        charge_point_id, 
-        port_id, 
-        location_id
+        charge_point_id,
+        port_id,
+        location_id,
+        decommissioned_ts
 )
 
 select
@@ -27,4 +29,6 @@ select
     ports.location_id,
     ports.port_id,
     ports.connector_count,
+    ports.decommissioned_ts,
+    ports.decommissioned_ts is null as is_active,
 from ports

--- a/models/marts/fact_downtime_daily.sql
+++ b/models/marts/fact_downtime_daily.sql
@@ -20,10 +20,8 @@ with incremental_date_range as (
 ports as (
     select
         charge_point_id,
-        port_id,
-        commissioned_ts,
-        decommissioned_ts
-    from {{ ref('int_ports') }}
+        port_id
+    from {{ ref('dim_ports') }}
 ),
 
 -- Get faulted outages first to filter offline outages

--- a/models/marts/fact_location_capacity.sql
+++ b/models/marts/fact_location_capacity.sql
@@ -1,0 +1,33 @@
+{{
+  config(
+    materialized='table',
+    description="One row per location. Physical capacity counts derived from int_ports. Full refresh — counts are overwritten when ports are commissioned or decommissioned."
+  )
+}}
+
+with ports as (
+    select
+        location_id,
+        charge_point_id,
+        port_id,
+        connector_id
+    from {{ ref('int_ports') }}
+),
+
+capacity as (
+    select
+        location_id,
+        count(distinct charge_point_id) as charge_point_count,
+        count(distinct charge_point_id || '|' || cast(port_id as varchar)) as port_count,
+        count(distinct charge_point_id || '|' || cast(port_id as varchar) || '|' || cast(connector_id as varchar)) as connector_count
+    from ports
+    group by location_id
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
+    location_id,
+    charge_point_count,
+    port_count,
+    connector_count
+from capacity

--- a/models/marts/fact_uptime.sql
+++ b/models/marts/fact_uptime.sql
@@ -6,8 +6,10 @@
 }}
 
 with ports as (
-    select distinct charge_point_id, port_id
-    from {{ ref('int_ports') }}
+    select
+        charge_point_id,
+        port_id
+    from {{ ref('dim_ports') }}
 ),
 
 span_port_days as (

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -429,6 +429,7 @@ new_visits as (
 {% endif %}
 
 select
+    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
     location_id,
     charge_point_ids,
     id_tag,

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -43,7 +43,7 @@ charge_attempts_with_location as (
             else null
         end as id_tag
     from {{ ref("fact_charge_attempts") }} att
-    inner join {{ ref("int_ports") }} p
+    inner join {{ ref("dim_connectors") }} p
         on att.charge_point_id = p.charge_point_id
         and att.connector_id = p.connector_id
     where att.incremental_ts > (select from_timestamp from incremental_date_range)

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -203,6 +203,13 @@ models:
         tests:
           - not_null
           - unique
+      - name: location_key
+        description: "Foreign key to dim_locations."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_locations')
+              field: location_key
       - name: location_id
         description: "Location identifier where the visit occurred"
         tests:
@@ -323,7 +330,7 @@ models:
         description: "Timestamp when the most recent status was ingested"
 
   - name: dim_locations
-    description: "Location dimension. One row per distinct location. Grain: one row per location_id."
+    description: "Conformed location dimension. One row per distinct charging location. SCD Type 1."
     columns:
       - name: location_key
         description: "Surrogate key for the location dimension, generated from location_id."
@@ -335,6 +342,44 @@ models:
         tests:
           - not_null
           - unique
+
+  - name: fact_location_capacity
+    description: "Physical capacity counts per location. One row per location. Full refresh — counts are overwritten when ports are commissioned or decommissioned. Join to dim_locations on location_key for site-level analysis."
+    columns:
+      - name: location_key
+        description: "Surrogate key matching dim_locations.location_key."
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              to: ref('dim_locations')
+              field: location_key
+      - name: location_id
+        description: "Natural key. Location identifier sourced from int_ports."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_count
+        description: "Number of distinct charge points (devices) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: port_count
+        description: "Number of distinct ports (charge_point + port combinations) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: connector_count
+        description: "Number of distinct connectors (charge_point + port + connector combinations) at this location."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
 
   - name: charge_point_span_daily
     description: "One row per charge point per day between commissioned and decommissioned, with minutes the charger was commissioned that day. Used for uptime and availability metrics."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -286,7 +286,7 @@ models:
   - name: dim_ports
     description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
     columns:
-      - name: port_sk
+      - name: port_key
         description: "Surrogate key for the port/connector dimension"
         tests:
           - not_null

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -6,20 +6,20 @@ models:
     columns:
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Identifier for the charging connector"
-        tests:
+        data_tests:
           - not_null
       - name: charge_attempt_id
         description: "Surrogate key for the charge attempt, generated from charge_point_id, connector_id, and charge_attempt_start_ts."
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: charge_attempt_start_ts
         description: "Start timestamp of the charge attempt. Uses preparing_start_ts (coalesce of payload_ts and ingested_ts from StatusNotification) if available, otherwise transaction_start_ts."
-        tests:
+        data_tests:
           - not_null
       - name: charge_attempt_stop_ts
         description: "Stop timestamp of the charge attempt. Uses transaction_stop_ts if transaction exists, otherwise preparing_stop_ts (coalesce of next_payload_ts and next_ingested_ts)."
@@ -37,7 +37,7 @@ models:
         description: "Status before changing to 'Preparing'"
       - name: status
         description: "Current status (should be 'Preparing')"
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ['Preparing']
@@ -49,7 +49,7 @@ models:
         description: "Array of authorization statuses merged from charge attempt and transaction events"
       - name: transaction_id
         description: "Transaction ID (from charge attempt or transaction data)"
-        tests:
+        data_tests:
           - unique
       - name: transaction_ingested_ts
         description: "Earliest timestamp when any OCPP event for this transaction was ingested"
@@ -69,16 +69,16 @@ models:
         description: "Array of error codes from both charge attempt events and StatusNotification events during the transaction"
       - name: is_successful
         description: "Boolean flag indicating if the charge attempt was successful. True when: there is a transaction, next status is not 'Faulted', transaction stop reason is 'Local', 'Remote' or 'EVDisconnected', and energy transferred is greater than 0.01 kWh."
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: [true, false]
       - name: incremental_ts
         description: "Latest incremental processing timestamp from both source models for incremental processing tracking"
-        tests:
+        data_tests:
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -96,52 +96,52 @@ models:
     columns:
       - name: charge_point_id
         description: "Unique identifier for the charging point"
-        tests:
+        data_tests:
           - not_null
       - name: transaction_id
         description: "Unique identifier for the charging transaction"
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Unique identifier for the connector within the charging point"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_ts
         description: "Timestamp when transaction was ingested into the system"
-        tests:
+        data_tests:
           - not_null
       - name: measurand
         description: "Type of measurement (e.g., Energy.Active.Import.Register, Voltage, Current.Import)"
-        tests:
+        data_tests:
           - not_null
       - name: unit
         description: "Unit of measurement (e.g., Wh, V, A, W)"
-        tests:
+        data_tests:
           - not_null
       - name: phase
         description: "Electrical phase (e.g., L1, L2, L3) or null for single-phase measurements"
       - name: meter_15min_interval_start
         description: "Start timestamp of the 15-minute interval. For the first interval, this is the actual first measurement time; for subsequent intervals, it's the 15-minute boundary."
-        tests:
+        data_tests:
           - not_null
       - name: meter_15min_interval_stop
         description: "End timestamp of the 15-minute interval. For the last interval, this is the actual last measurement time; for other intervals, it's the next 15-minute boundary."
-        tests:
+        data_tests:
           - not_null
       - name: avg_value
         description: "Average value for the measurand within this 15-minute interval"
-        tests:
+        data_tests:
           - not_null
       - name: _count
         description: "Number of measurements within this 15-minute interval"
-        tests:
+        data_tests:
           - not_null
       - name: interval_data_id
         description: "Surrogate key for the interval data record, generated from charge_point_id, transaction_id, ingested_ts, connector_id, measurand, unit, phase, and meter_15min_interval_start"
-        tests:
+        data_tests:
           - unique
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -159,34 +159,34 @@ models:
     columns:
       - name: date_id
         description: "Calendar date for the downtime aggregation"
-        tests:
+        data_tests:
           - not_null
       - name: charge_point_id
         description: "Identifier for the charge point"
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Port identifier associated with the charge point (may be null if unavailable)"
       - name: duration_minutes
         description: "Total downtime minutes for the date/charge_point/port combination"
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 0
       - name: type
         description: "Downtime type. Currently always 'OFFLINE'."
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: ['OFFLINE', 'FAULTED']
       - name: downtime_id
         description: "Surrogate key for the downtime record, generated from date_id, charge_point_id, port_id, and type"
-        tests:
+        data_tests:
           - unique
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -200,33 +200,33 @@ models:
     columns:
       - name: visit_id
         description: "Unique identifier for the visit, generated from location_id, first_charge_point_id, and visit_start_ts"
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: location_key
         description: "Foreign key to dim_locations."
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('dim_locations')
               field: location_key
       - name: location_id
         description: "Location identifier where the visit occurred"
-        tests:
+        data_tests:
           - not_null
       - name: id_tag
         description: "Driver identifier (RFID tag). Null for visits where authorization failed. May be inferred from subsequent authorized attempts within 2 minutes on the same charger."
       - name: visit_start_ts
         description: "Start timestamp of the first charge attempt in the visit (charge_attempt_start_ts)"
-        tests:
+        data_tests:
           - not_null
       - name: visit_end_ts
         description: "Stop timestamp of the last charge attempt in the visit (charge_attempt_stop_ts)"
-        tests:
+        data_tests:
           - not_null
       - name: charge_attempt_count
         description: "Number of charge attempts in this visit"
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
@@ -247,7 +247,7 @@ models:
         description: "Total energy transferred across all charge attempts in this visit (kWh)"
       - name: visit_duration_minutes
         description: "Duration of the visit in minutes (from first charge_attempt_start_ts to last charge_attempt_stop_ts)"
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
@@ -258,16 +258,16 @@ models:
         description: "Charge point ID where the visit ended"
       - name: is_successful
         description: "Success status of the last charge attempt in the visit"
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: [true, false]
       - name: incremental_ts
         description: "Latest incremental processing timestamp for incremental processing tracking"
-        tests:
+        data_tests:
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -295,37 +295,37 @@ models:
     columns:
       - name: charge_point_key
         description: "Surrogate key for the charge point, generated from charge_point_id."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: charge_point_id
         description: "Natural key. Unique identifier for the charge point."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: location_id
         description: "Location where this charge point is installed."
-        tests:
+        data_tests:
           - not_null
           - relationships:
               to: ref('dim_locations')
               field: location_id
       - name: commissioned_ts
         description: "Timestamp when the charge point was commissioned."
-        tests:
+        data_tests:
           - not_null
       - name: decommissioned_ts
         description: "Timestamp when the charge point was decommissioned. Null if still active."
       - name: is_active
         description: "True if the charge point has not been decommissioned."
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: [true, false]
       - name: port_count
         description: "Number of ports on this charge point."
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               min_value: 1
@@ -335,28 +335,28 @@ models:
     columns:
       - name: port_key
         description: "Surrogate key for the port, generated from charge_point_id and port_id."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: charge_point_id
         description: "Charge point this port belongs to."
-        tests:
+        data_tests:
           - not_null
       - name: location_id
         description: "Location where this port is installed."
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Port identifier within the charge point."
-        tests:
+        data_tests:
           - not_null
       - name: connector_count
         description: "Number of connectors on this port."
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               min_value: 1
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -368,35 +368,35 @@ models:
     columns:
       - name: connector_key
         description: "Surrogate key for the connector, generated from charge_point_id, port_id, and connector_id."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: charge_point_id
         description: "Charge point this connector belongs to."
-        tests:
+        data_tests:
           - not_null
       - name: location_id
         description: "Location where this connector is installed."
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Port this connector belongs to."
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Connector identifier within the port."
-        tests:
+        data_tests:
           - not_null
       - name: connector_type
         description: "Plug standard for this connector (e.g. CCS, NACS)."
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values: ['CCS', 'NACS', 'CHAdeMO', 'Type1', 'Type2']
       - name: latest_status
         description: "Most recent OCPP status reported by this connector. Null if no StatusNotification has been received yet."
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ['Available', 'Preparing', 'Charging', 'SuspendedEVSE', 'SuspendedEV', 'Finishing', 'Reserved', 'Unavailable', 'Faulted']
@@ -404,7 +404,7 @@ models:
         description: "Error code from the most recent StatusNotification (e.g. NoError, ConnectorLockFailure)."
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested."
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -417,12 +417,12 @@ models:
     columns:
       - name: location_key
         description: "Surrogate key for the location dimension, generated from location_id."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: location_id
         description: "Natural key. Location identifier sourced from stg_ports."
-        tests:
+        data_tests:
           - not_null
           - unique
 
@@ -431,7 +431,7 @@ models:
     columns:
       - name: location_key
         description: "Surrogate key matching dim_locations.location_key."
-        tests:
+        data_tests:
           - not_null
           - unique
           - relationships:
@@ -439,26 +439,26 @@ models:
               field: location_key
       - name: location_id
         description: "Natural key. Location identifier sourced from int_ports."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: charge_point_count
         description: "Number of distinct charge points (devices) at this location."
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 1
       - name: port_count
         description: "Number of distinct ports (charge_point + port combinations) at this location."
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 1
       - name: connector_count
         description: "Number of distinct connectors (charge_point + port + connector combinations) at this location."
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
@@ -469,17 +469,17 @@ models:
     columns:
       - name: charge_point_id
         description: "Charger identifier"
-        tests:
+        data_tests:
           - not_null
       - name: date_id
         description: "Calendar day (date)"
-        tests:
+        data_tests:
           - not_null
       - name: minutes
         description: "Minutes the charger was commissioned on this day (partial on first/last day of commission range)"
-        tests:
+        data_tests:
           - not_null
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -491,24 +491,24 @@ models:
     columns:
       - name: uptime_id
         description: "Surrogate key for the row (charge_point_id, port_id, date_id)"
-        tests:
+        data_tests:
           - unique
           - not_null
       - name: charge_point_id
         description: "Charger identifier"
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Port identifier within the charger"
-        tests:
+        data_tests:
           - not_null
       - name: date_id
         description: "Calendar day (date)"
-        tests:
+        data_tests:
           - not_null
       - name: uptime
         description: "Fraction of commissioned minutes that were not outage; 1 = fully up, 0 = fully down"
-        tests:
+        data_tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -330,7 +330,8 @@ models:
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
-              min_value: 1
+              arguments:
+                min_value: 1
 
   - name: dim_ports
     description: "Port dimension. One row per (charge_point_id, port_id). Use for faulted outages, port-level uptime, port inventory, operational analysis."
@@ -357,7 +358,8 @@ models:
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
-              min_value: 1
+              arguments:
+                min_value: 1
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -350,7 +350,7 @@ models:
         description: "Port identifier within the charge point."
         tests:
           - not_null
-      - name: connectors_count
+      - name: connector_count
         description: "Number of connectors on this port."
         tests:
           - not_null

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -323,6 +323,12 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: port_count
+        description: "Number of ports on this charge point."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 1
 
   - name: dim_ports
     description: "Port dimension. One row per (charge_point_id, port_id). Use for faulted outages, port-level uptime, port inventory, operational analysis."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -290,44 +290,129 @@ models:
         description: "Date at day granularity; used as time spine standard granularity column"
         granularity: day
   
-  - name: dim_ports
-    description: "Port/connector dimension. Full refresh from stg_ports. Charger means a device with one or more charging ports and connectors for charging EVs (EVSE)."
+  - name: dim_charge_points
+    description: "Charge point dimension. One row per charge point. Use for offline outages, charger-level uptime and availability, charger inventory, and visit attribution at charger level."
     columns:
-      - name: port_key
-        description: "Surrogate key for the port/connector dimension"
+      - name: charge_point_key
+        description: "Surrogate key for the charge point, generated from charge_point_id."
         tests:
           - not_null
           - unique
       - name: charge_point_id
-        description: "Charger identifier"
+        description: "Natural key. Unique identifier for the charge point."
+        tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: "Location where this charge point is installed."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_locations')
+              field: location_id
+      - name: commissioned_ts
+        description: "Timestamp when the charge point was commissioned."
+        tests:
+          - not_null
+      - name: decommissioned_ts
+        description: "Timestamp when the charge point was decommissioned. Null if still active."
+      - name: port_count
+        description: "Number of ports on this charge point."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: connector_count
+        description: "Number of connectors on this charge point across all ports."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: is_active
+        description: "True if the charge point has not been decommissioned."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+  - name: dim_ports
+    description: "Port dimension. One row per (charge_point_id, port_id). Use for faulted outages, port-level uptime, port inventory, operational analysis."
+    columns:
+      - name: port_key
+        description: "Surrogate key for the port, generated from charge_point_id and port_id."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_id
+        description: "Charge point this port belongs to."
         tests:
           - not_null
       - name: location_id
-        description: "Location identifier where the charger is located"
+        description: "Location where this port is installed."
+        tests:
+          - not_null
       - name: port_id
-        description: "Port identifier within the charger"
+        description: "Port identifier within the charge point."
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+
+  - name: dim_connectors
+    description: "Connector dimension. One row per (charge_point_id, port_id, connector_id). Use for connector-type analysis, current inventory, and connector-specific operational reporting if needed. Finest-grain hardware dimension."
+    columns:
+      - name: connector_key
+        description: "Surrogate key for the connector, generated from charge_point_id, port_id, and connector_id."
+        tests:
+          - not_null
+          - unique
+      - name: charge_point_id
+        description: "Charge point this connector belongs to."
+        tests:
+          - not_null
+      - name: location_id
+        description: "Location where this connector is installed."
+        tests:
+          - not_null
+      - name: port_id
+        description: "Port this connector belongs to."
         tests:
           - not_null
       - name: connector_id
-        description: "Connector identifier within the port"
+        description: "Connector identifier within the port."
         tests:
           - not_null
       - name: connector_type
-        description: "Type of connector (e.g., CCS, NACS)"
-      - name: commissioned_ts
-        description: "Timestamp when the charger was commissioned (null if not commissioned yet)"
-      - name: decommissioned_ts
-        description: "Timestamp when the charger was decommissioned (null if still active)"
+        description: "Plug standard for this connector (e.g. CCS, NACS)."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['CCS', 'NACS', 'CHAdeMO', 'Type1', 'Type2']
       - name: latest_status
-        description: "Most recent OCPP status reported by this connector (null if no status has been received)"
+        description: "Most recent OCPP status reported by this connector. Null if no StatusNotification has been received yet."
         tests:
           - accepted_values:
               arguments:
                 values: ['Available', 'Preparing', 'Charging', 'SuspendedEVSE', 'SuspendedEV', 'Finishing', 'Reserved', 'Unavailable', 'Faulted']
       - name: latest_error_code
-        description: "Error code from the most recent StatusNotification (e.g., NoError, ConnectorLockFailure)"
+        description: "Error code from the most recent StatusNotification (e.g. NoError, ConnectorLockFailure)."
       - name: latest_status_ts
-        description: "Timestamp when the most recent status was ingested"
+        description: "Timestamp when the most recent status was ingested."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - charge_point_id
+              - port_id
+              - connector_id
 
   - name: dim_locations
     description: "Conformed location dimension. One row per distinct charging location. SCD Type 1."

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -358,15 +358,8 @@ models:
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
-              min_value: 1
-      - name: decommissioned_ts
-        description: "Timestamp when this port was decommissioned. Null if still active."
-      - name: is_active
-        description: "True when the port has not been decommissioned."
-        data_tests:
-          - not_null
-          - accepted_values:
-              values: [true, false]
+              arguments:
+                min_value: 1
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -358,8 +358,15 @@ models:
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
+              min_value: 1
+      - name: decommissioned_ts
+        description: "Timestamp when this port was decommissioned. Null if still active."
+      - name: is_active
+        description: "True when the port has not been decommissioned."
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -208,8 +208,9 @@ models:
         data_tests:
           - not_null
           - relationships:
-              to: ref('dim_locations')
-              field: location_key
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: location_id
         description: "Location identifier where the visit occurred"
         data_tests:
@@ -308,8 +309,9 @@ models:
         data_tests:
           - not_null
           - relationships:
-              to: ref('dim_locations')
-              field: location_id
+              arguments:
+                to: ref('dim_locations')
+                field: location_id
       - name: commissioned_ts
         description: "Timestamp when the charge point was commissioned."
         data_tests:
@@ -435,8 +437,9 @@ models:
           - not_null
           - unique
           - relationships:
-              to: ref('dim_locations')
-              field: location_key
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: location_id
         description: "Natural key. Location identifier sourced from int_ports."
         data_tests:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -316,20 +316,6 @@ models:
           - not_null
       - name: decommissioned_ts
         description: "Timestamp when the charge point was decommissioned. Null if still active."
-      - name: port_count
-        description: "Number of ports on this charge point."
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
-      - name: connector_count
-        description: "Number of connectors on this charge point across all ports."
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
       - name: is_active
         description: "True if the charge point has not been decommissioned."
         tests:
@@ -358,6 +344,12 @@ models:
         description: "Port identifier within the charge point."
         tests:
           - not_null
+      - name: connectors_count
+        description: "Number of connectors on this port."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 1
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -322,6 +322,20 @@ models:
       - name: latest_status_ts
         description: "Timestamp when the most recent status was ingested"
 
+  - name: dim_locations
+    description: "Location dimension. One row per distinct location. Grain: one row per location_id."
+    columns:
+      - name: location_key
+        description: "Surrogate key for the location dimension, generated from location_id."
+        tests:
+          - not_null
+          - unique
+      - name: location_id
+        description: "Natural key. Location identifier sourced from stg_ports."
+        tests:
+          - not_null
+          - unique
+
   - name: charge_point_span_daily
     description: "One row per charge point per day between commissioned and decommissioned, with minutes the charger was commissioned that day. Used for uptime and availability metrics."
     columns:

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -64,7 +64,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -134,7 +134,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -205,7 +205,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:40:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -276,7 +276,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -345,7 +345,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -415,7 +415,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 12:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -486,7 +486,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -556,7 +556,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 13:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -681,7 +681,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:20:00' as timestamp) as incremental_ts              
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -749,7 +749,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 10:20:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -816,7 +816,7 @@ unit_tests:
               cast(null as array) as error_codes,
               false as is_successful,
               cast('2025-10-02 11:02:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -884,7 +884,7 @@ unit_tests:
               cast(null as array) as error_codes,
               true as is_successful,
               cast('2025-10-02 12:05:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_connectors')
         format: sql
         fixture: stg_ports_fixture
     expect:
@@ -1264,7 +1264,7 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, cast('2025-10-01 10:30:00' as timestamp) as from_ts, cast('2025-10-01 12:30:00' as timestamp) as to_ts, 120 as duration_minutes, cast('2025-10-01 12:30:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
@@ -1293,7 +1293,7 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, cast('2025-10-01 22:00:00' as timestamp) as from_ts, cast('2025-10-02 04:00:00' as timestamp) as to_ts, 360 as duration_minutes, cast('2025-10-02 12:00:00' as timestamp) as incremental_ts
-      - input: ref('int_ports')
+      - input: ref('dim_ports')
         format: sql
         rows: |
           select 'CH-001' as charge_point_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts

--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -1,6 +1,50 @@
 version: 2
 
 semantic_models:
+  - name: charge_points
+    description: "Charge point dimension. Use to slice metrics by charger lifecycle attributes (active/decommissioned, port count, connector count)."
+    model: ref('dim_charge_points')
+    entities:
+      - name: charge_point
+        type: primary
+        expr: charge_point_id
+    dimensions:
+      - name: is_active
+        type: categorical
+        description: "True if the charge point has not been decommissioned."
+      - name: location_id
+        type: categorical
+
+  - name: ports
+    description: "Port dimension. Use to slice uptime and downtime metrics by port."
+    model: ref('dim_ports')
+    entities:
+      - name: port
+        type: primary
+        expr: port_key
+    dimensions:
+      - name: charge_point_id
+        type: categorical
+      - name: location_id
+        type: categorical
+
+  - name: connectors
+    description: "Connector dimension. Use to slice metrics by connector type or current status."
+    model: ref('dim_connectors')
+    entities:
+      - name: connector
+        type: primary
+        expr: connector_key
+    dimensions:
+      - name: connector_type
+        type: categorical
+      - name: latest_status
+        type: categorical
+      - name: charge_point_id
+        type: categorical
+      - name: location_id
+        type: categorical
+
   - name: visits
     description: ""
     model: ref('fact_visits')
@@ -13,6 +57,9 @@ semantic_models:
       - name: charge_attempt
         type: foreign
         expr: last_charge_attempt_id
+      - name: location
+        type: foreign
+        expr: location_key
     dimensions:
       - name: visit_end_ts
         type: time
@@ -104,6 +151,9 @@ semantic_models:
       - name: charge_attempt
         type: primary
         expr: charge_attempt_id
+      - name: charge_point
+        type: foreign
+        expr: charge_point_id
     dimensions:
       - name: charge_attempt_start_ts
         type: time
@@ -174,6 +224,9 @@ semantic_models:
       - name: uptime_record
         type: primary
         expr: uptime_id
+      - name: charge_point
+        type: foreign
+        expr: charge_point_id
     dimensions:
       - name: date_id
         type: time

--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -189,6 +189,18 @@ semantic_models:
         agg: average
         expr: uptime
 
+  - name: locations
+    description: "Location dimension. One row per distinct location observed in port data."
+    model: ref('dim_locations')
+    # No defaults.agg_time_dimension: this is an attribute-only dimension with no time column or measures.
+    entities:
+      - name: location
+        type: primary
+        expr: location_key
+    dimensions:
+      - name: location_id
+        type: categorical
+
 metrics:
   - name: total_visits
     description: "Total number of charging visits"

--- a/models/staging/raw/staging.yml
+++ b/models/staging/raw/staging.yml
@@ -51,19 +51,19 @@ models:
     columns:
       - name: charge_point_id
         description: "Charge point identifier"
-        tests:
+        data_tests:
           - not_null
       - name: message_type_id
         description: "OCPP message type: 2 = CALL (request), 3 = CALLRESULT (response)"
-        tests:
+        data_tests:
           - not_null
       - name: unique_id
         description: "OCPP message identifier, unique per charge point per direction"
-        tests:
+        data_tests:
           - not_null
       - name: ingested_timestamp
         description: "Timestamp when the message was received"
-        tests:
+        data_tests:
           - not_null
 
   - name: stg_ports
@@ -71,23 +71,23 @@ models:
     columns:
       - name: charge_point_id
         description: "Charger identifier. Charger means a device with one or more charging ports and connectors for charging EVs, also referred to as Electric Vehicle Supply Equipment (EVSE)."
-        tests:
+        data_tests:
           - not_null
       - name: location_id
         description: "Location identifier where the charge point is located"
-        tests:
+        data_tests:
           - not_null
       - name: port_id
         description: "Port identifier within the charge point. Charging port means the system within a charger that charges one EV. A charging port may have multiple connectors, but it can provide power to charge only one EV through one connector at a time."
-        tests:
+        data_tests:
           - not_null
       - name: connector_id
         description: "Connector identifier within the port"
-        tests:
+        data_tests:
           - not_null
       - name: connector_type
         description: "Type of connector (e.g., CCS, NACS)"
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -96,7 +96,7 @@ models:
         description: "Timestamp when the charge point was commissioned (null if not commissioned yet)"
       - name: decommissioned_ts
         description: "Timestamp when the charge point was decommissioned (null if still active)"
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:


### PR DESCRIPTION
Summary

Adds a new dim_locations Kimball-style dimension to the marts layer. This unblocks the companion issue that will wire location_key as a foreign key across all five fact tables. Location is now a first-class dimension with a stable surrogate key, consistent with the existing dim_ports / dim_drivers / dim_dates pattern.

Why

Every fact table currently embeds location_id as a raw natural key with no canonical dimension behind it. This violates the project's Kimball-aligned modeling pattern and makes location-level slicing in dashboards and the semantic layer fragile. The initial dimension is intentionally attribute-sparse — only location_key and location_id — because no other location metadata exists in the source data yet.

Changes

New file
- models/marts/dim_locations.sql — table materialization, two-CTE structure (ports → locations), surrogate key generated via dbt_utils.generate_surrogate_key(['location_id']). Grain: one row per distinct location_id. Source: stg_ports.

Updated files
- models/marts/marts.yml — new dim_locations block with model-level description and column-level docs. Tests: not_null + unique on both location_key and location_id.
- models/semantic/semantic_models.yml — new locations semantic model pointing to ref('dim_locations'), primary entity location keyed on location_key, categorical dimension location_id, no measures. Includes a comment documenting why defaults.agg_time_dimension is deliberately omitted (attribute-only dimension, no time column).

Out of scope (companion issue)

- Wiring location_key as a foreign key in fact_visits, fact_charge_attempts, fact_uptime, etc.
- Enrichment attributes (name, address, region) — no source data available yet.

QA verdict

All acceptance criteria pass. The agg_time_dimension omission is now documented inline.

Definition of done status

- Model created ✓
- Tests defined ✓
- Docs added ✓
- Semantic layer updated ✓

Closes #95 

---

UPD:
Builds the hardware dimension layer and rewires facts off intermediate models

The project had no proper dimension models for charge points, ports, or connectors. Facts were joining directly to int_ports, which is the wrong layer and was causing silent fan-out bugs. This PR introduces dim_charge_points, corrects dim_ports to port grain, renames the old broken dim_ports to dim_connectors, and rewires all three affected facts to join the marts layer instead. Semantic models for all three new dimensions are also wired in.


What changed

New model: dim_charge_points
- One row per charge point. Natural key: charge_point_id. Surrogate: charge_point_key.
- Carries commissioned_ts, decommissioned_ts, port_count, connector_count, is_active.
- Fixes: wrong surrogate key name (port_key) and syntax error present on the branch.

Corrected model: dim_ports
- Now at port grain: one row per (charge_point_id, port_id).
- commissioned_ts/decommissioned_ts removed -- charge point attributes, not port attributes. They now live only in dim_charge_points.

New model: dim_connectors (was the broken dim_ports)
- One row per (charge_point_id, port_id, connector_id).
- Joins int_ports to int_connector_latest_status for latest_status, latest_error_code, latest_status_ts.
- connector_type stays here -- it is a connector attribute.

Facts rewired
- fact_downtime_daily -- ports CTE sourced int_ports without DISTINCT, producing connector fan-out before the offline outage join. Now sources dim_ports.
- fact_uptime -- ports CTE used an ad-hoc SELECT DISTINCT on int_ports (correct result, wrong layer). Now sources dim_ports.
- fact_visits -- was joining int_ports to resolve location_id and port_id. Now joins dim_connectors.

Tests added
- dim_charge_points: surrogate key unique+not_null; charge_point_id unique+not_null; location_id relationship to dim_locations; port_count/connector_count range >= 1; is_active accept
- dim_ports: surrogate key unique+not_null; composite grain test on (charge_point_id, port_id).
- dim_connectors: surrogate key unique+not_null; composnt_id, port_id, connector_id); connector_type andlatest_status accepted_values.
- fact_visits tests was mocking ref('int_ports'). Now -> ref('dim_connectors')
- fact_downtime_daily tests was mocking ref('int_ports'). Now -> ref('dim_ports')

Yml files
- data tests conform to the new naming data_tests

Semantic layer
- New semantic models: charge_points, ports, connectors
- charge_point FK entity added to charge_attempts and uptime (joined on charge_point_id).
- location FK entity added to visits -- location_key wad as an entity, making it invisible to MetricFlow.



---
Why                                                                                                                                          
Grain correctness is the core issue. int_ports is connector-grain. Any CTE selecting from it without DISTINCT on a higher-grain key fans out silently. fact_downtime_daily had exactly this bug. Then every fact -- it's dimension models at the correctgrain.


Intermediate models are not for direct fact joins. Pulling int_ports into fact_visits couples two marts to the same intermediate, making grain changes fragile. Facts should join dims.


Attribute assignment follows grain. commissioned_ts/decally across every connector row in int_ports. Carryingthem into dim_ports or dim_connectors implies a port or connector can be independently commissioned -- which isn't modeled here. They belong in dim_charge_points only.


The old dim_ports was connector-grain in everything butbuilt on (charge_point_id, port_id, connector_id), itselected connector_id and connector_type, and joined to int_connector_latest_status. Renaming it dim_connectors makes vocabulary match grain before any downstream consumer can trust it.
