### PR TITLE
full history demo evals fix

### DIFF
--- a/demo/chat-bi/tests/lately_snapshot.yml
+++ b/demo/chat-bi/tests/lately_snapshot.yml
@@ -1,5 +1,5 @@
 name: lately_snapshot
-prompt: "Give me a quick snapshot of uptime and failed charging attempts."
+prompt: "Show me uptime and failed charge attempts for the full history."
 sql: |
   SELECT
     (

--- a/demo/chat-bi/tests/network_reliability_uptime.yml
+++ b/demo/chat-bi/tests/network_reliability_uptime.yml
@@ -1,5 +1,5 @@
 name: network_reliability_uptime
-prompt: "What is the overall uptime percentage of my EV charging network?"
+prompt: "What is the overall uptime percentage of my EV charging network for the full history.?"
 sql: |
   SELECT ROUND(AVG(uptime) * 100, 2) AS overall_uptime_pct
   FROM analytics.ANALYTICS.fact_uptime

--- a/demo/chat-bi/tests/network_reliability_uptime.yml
+++ b/demo/chat-bi/tests/network_reliability_uptime.yml
@@ -1,5 +1,5 @@
 name: network_reliability_uptime
-prompt: "What is the overall uptime percentage of my EV charging network for the full history.?"
+prompt: "What is the overall uptime percentage of my EV charging network for the full history?"
 sql: |
   SELECT ROUND(AVG(uptime) * 100, 2) AS overall_uptime_pct
   FROM analytics.ANALYTICS.fact_uptime

--- a/demo/dbt/entrypoint.sh
+++ b/demo/dbt/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Installing dbt packages..."
 dbt deps --log-path /tmp/dbt-logs
 
 echo "Running dbt run (staging → intermediate → marts)..."
-dbt run --target duckdb --log-path /tmp/dbt-logs
+dbt run --target duckdb --full-refresh --log-path /tmp/dbt-logs
 
 echo "Running dbt tests (failures reported but do not block startup)..."
 dbt test --target duckdb --log-path /tmp/dbt-logs --exclude "test_type:unit" || echo "Some tests failed — see logs."


### PR DESCRIPTION
avoid querying (rightfully) last 7d in tests:

```
  SELECT ROUND(AVG(uptime) * 100, 2) AS overall_uptime_pct
  FROM analytics.ANALYTICS.fact_uptime
  WHERE date_id >= CURRENT_DATE - INTERVAL '7’ DAYS
```

results:

<img width="917" height="150" alt="Screenshot 2026-06-18 at 12 35 54 PM" src="https://github.com/user-attachments/assets/d6d00e18-83b8-466d-a8f0-c0608e4b5112" />


The ports test also fixed in a different PR: https://github.com/appspace/kwwhat/pull/118