### PR TITLE
Rename full history demo eval test

### DIFF
--- a/demo/chat-bi/tests/full_history_snapshot.yml
+++ b/demo/chat-bi/tests/full_history_snapshot.yml
@@ -1,4 +1,4 @@
-name: lately_snapshot
+name: full_history_snapshot
 prompt: "Show me uptime and failed charge attempts for the full history."
 sql: |
   SELECT


### PR DESCRIPTION
Renames the full-history demo eval from `lately_snapshot` to `full_history_snapshot` so the test name matches the updated prompt from #122.

No SQL or expected behavior changes.