### PR TITLE
Cleanup 3

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,11 +1,8 @@
 packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
   - name: fivetran_utils
     package: fivetran/fivetran_utils
-    version: 0.4.11
-  - name: dbt_project_evaluator
-    package: dbt-labs/dbt_project_evaluator
-    version: 1.2.3
-sha1_hash: a8a25942bb079788bf7ed9767907d2a2650191b5
+    version: 0.4.12
+sha1_hash: d4e74cdfdc5e902c00828d32bbd2b3227e3872f8

--- a/packages.yml
+++ b/packages.yml
@@ -3,5 +3,3 @@ packages:
     version: [">=1.0.0", "<2.0.0"]
   - package: fivetran/fivetran_utils
     version: [">=0.4.0", "<0.5.0"]
-  - package: dbt-labs/dbt_project_evaluator
-    version: [">=0.8.0"]


### PR DESCRIPTION
removed dbt Project Evaluator  to stop output schema pollution. Will be beringing it back periodically for audit. 
Last feedback is captured here https://github.com/appspace/kwwhat/issues/127 