### PR TITLE
Keys to marts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,24 @@ Every model must define:
 
 If grain is unclear → stop and ask.
 
+### Naming
+
+- **natural business identifiers**: `charger_id`, `port_id` — the domain's own IDs, carried through as-is
+- **dimension foreign keys, where helpful**: `port_key` — surrogate FK, computed once in the owning dimension
+- **fact row identifiers**: `visit_id`, `downtime_id`, `uptime_id` — the fact's own surrogate PK at its grain
+
+### Facts don't recompute dimension keys
+
+A `_key` is owned by its dimension. Facts join the dimension and reuse `dim.<x>_key` — they don't rederive it with their own `generate_surrogate_key(...)` call.
+
+### Column order in fact `select` statements
+
+`<fact>_id` first, then its `_key`s, then everything else:
+
+```
+<fact>_id, <dim>_key, <dim>_key, ..., <business columns...>
+```
+
 ---
 
 ## Testing Requirements

--- a/models/marts/fact_charge_attempts.sql
+++ b/models/marts/fact_charge_attempts.sql
@@ -208,6 +208,10 @@ attempts_and_transactions as (
 {% endif %}
 
 select
+    -- Generate a deterministic unique ID from the composite key
+    {{ dbt_utils.generate_surrogate_key([
+        'charger_id', 'connector_id', 'charge_attempt_start_ts'
+    ]) }} as charge_attempt_id,
     charger_id,
     connector_id,
     charge_attempt_start_ts,
@@ -238,10 +242,6 @@ select
     meter_stop_wh,
     energy_transferred_kwh,
     error_codes,
-    -- Generate a deterministic unique ID from the composite key
-    {{ dbt_utils.generate_surrogate_key([
-        'charger_id', 'connector_id', 'charge_attempt_start_ts'
-    ]) }} as charge_attempt_id,
     case
         when transaction_id is not null
             and (next_status is null or next_status != 'Faulted')

--- a/models/marts/fact_downtime_daily.sql
+++ b/models/marts/fact_downtime_daily.sql
@@ -19,6 +19,7 @@ with incremental_date_range as (
 
 ports as (
     select
+        port_key,
         charger_id,
         port_id
     from {{ ref('dim_ports') }}
@@ -27,16 +28,20 @@ ports as (
 -- Get faulted outages first to filter offline outages
 faulted_outages as (
     select
-        charger_id,
-        port_id,
-        from_ts,
-        to_ts,
-        duration_minutes,
-        incremental_ts,
+        f.charger_id,
+        f.port_id,
+        p.port_key,
+        f.from_ts,
+        f.to_ts,
+        f.duration_minutes,
+        f.incremental_ts,
         'FAULTED' as reason
-    from {{ ref('int_faulted_outages') }}
-    where incremental_ts > (select buffer_from_timestamp from incremental_date_range)
-        and incremental_ts <= (select to_timestamp from incremental_date_range)
+    from {{ ref('int_faulted_outages') }} as f
+    inner join ports as p
+        on f.charger_id = p.charger_id
+       and f.port_id = p.port_id
+    where f.incremental_ts > (select buffer_from_timestamp from incremental_date_range)
+        and f.incremental_ts <= (select to_timestamp from incremental_date_range)
 ),
 
 -- for Offline outages (charge point level, need to join with ports)
@@ -45,6 +50,7 @@ offline_outages as (
     select
         o.charger_id,
         p.port_id,
+        p.port_key,
         o.from_ts,
         o.to_ts,
         o.duration_minutes,
@@ -65,9 +71,9 @@ offline_outages as (
 ),
 
 outages as (
-    select charger_id, port_id, from_ts, to_ts, duration_minutes, incremental_ts, reason from offline_outages
+    select charger_id, port_id, port_key, from_ts, to_ts, duration_minutes, incremental_ts, reason from offline_outages
     union all
-    select charger_id, port_id, from_ts, to_ts, duration_minutes, incremental_ts, reason from faulted_outages
+    select charger_id, port_id, port_key, from_ts, to_ts, duration_minutes, incremental_ts, reason from faulted_outages
 ),
 
 filtered_outages as (
@@ -89,10 +95,11 @@ outage_days as (
     select
         o.charger_id,
         o.port_id,
+        o.port_key,
         o.date_id,
         o.reason,
         greatest(o.from_ts, o.date_id) as interval_start,
-        least(o.to_ts, {{ dbt.dateadd('day', 1, "o.date_id") }}) as interval_end
+        least(o.to_ts, {{ dbt.dateadd('day', 1, 'o.date_id') }}) as interval_end
     from filtered_outages as o
 ),
 
@@ -100,6 +107,7 @@ per_day as (
     select
         charger_id,
         port_id,
+        port_key,
         date_id,
         reason,
         {{ dbt.datediff('interval_start', 'interval_end', 'minutes') }} as duration_minutes
@@ -111,15 +119,17 @@ final as (
         date_id,
         charger_id,
         port_id,
+        port_key,
         reason,
         sum(duration_minutes) as duration_minutes
     from per_day
-    group by 1, 2, 3, 4
+    group by 1, 2, 3, 4, 5
 )
 
 select
     date_id,
     charger_id,
+    port_key,
     port_id,
     reason,
     duration_minutes,

--- a/models/marts/fact_downtime_daily.sql
+++ b/models/marts/fact_downtime_daily.sql
@@ -127,13 +127,13 @@ final as (
 )
 
 select
+    -- Generate a deterministic unique ID from the composite key
+    {{ dbt_utils.generate_surrogate_key(['date_id', 'charger_id', 'port_id', 'reason']) }} as downtime_id,
+    port_key,
     date_id,
     charger_id,
-    port_key,
     port_id,
     reason,
     duration_minutes,
-    -- Generate a deterministic unique ID from the composite key
-    {{ dbt_utils.generate_surrogate_key(['date_id', 'charger_id', 'port_id', 'reason']) }} as downtime_id,
     (select incremental_ts from incremental) as incremental_ts
 from final

--- a/models/marts/fact_interval_data.sql
+++ b/models/marts/fact_interval_data.sql
@@ -250,6 +250,11 @@ with incremental_date_range as (
     )
 
     select
+        -- Generate a deterministic unique ID from the composite key
+        {{ dbt_utils.generate_surrogate_key([
+            'charger_id', 'transaction_id', 'ingested_ts',
+            'connector_id', 'measurand', 'unit', 'phase', 'meter_15min_interval_start'
+        ]) }} as interval_data_id,
         charger_id,
         transaction_id,
         ingested_ts,
@@ -261,10 +266,5 @@ with incremental_date_range as (
         meter_15min_interval_stop,
         avg_value,
         _count,
-        -- Generate a deterministic unique ID from the composite key
-        {{ dbt_utils.generate_surrogate_key([
-            'charger_id', 'transaction_id', 'ingested_ts',
-            'connector_id', 'measurand', 'unit', 'phase', 'meter_15min_interval_start'
-        ]) }} as interval_data_id,
         (select incremental_ts from incremental) as incremental_ts
     from final

--- a/models/marts/fact_uptime.sql
+++ b/models/marts/fact_uptime.sql
@@ -49,8 +49,8 @@ with_downtime as (
 
 select
     {{ dbt_utils.generate_surrogate_key(['charger_id', 'port_id', 'date_id']) }} as uptime_id,
-    charger_id,
     port_key,
+    charger_id,
     port_id,
     date_id,
     (minutes_commissioned - total_downtime_minutes) / minutes_commissioned as uptime

--- a/models/marts/fact_uptime.sql
+++ b/models/marts/fact_uptime.sql
@@ -1,12 +1,13 @@
 {{
   config(
     materialized='view',
-    description='One row per charge point, port, and day: uptime = (minutes commissioned that day minus total outage minutes) / minutes commissioned that day.'
+    description='One row per charger, port, and day: uptime = (minutes commissioned that day minus total outage minutes) / minutes commissioned that day.'
   )
 }}
 
 with ports as (
     select
+        port_key,
         charger_id,
         port_id
     from {{ ref('dim_ports') }}
@@ -15,6 +16,7 @@ with ports as (
 span_port_days as (
     select
         p.charger_id,
+        p.port_key,
         p.port_id,
         s.date_id,
         s.minutes as minutes_commissioned
@@ -25,30 +27,30 @@ span_port_days as (
 downtime_agg as (
     select
         date_id,
-        charger_id,
-        port_id,
+        port_key,
         sum(duration_minutes) as total_downtime_minutes
     from {{ ref('fact_downtime_daily') }}
-    group by date_id, charger_id, port_id
+    group by date_id, port_key
 ),
 
 with_downtime as (
     select
         s.charger_id,
+        s.port_key,
         s.port_id,
         s.date_id,
         s.minutes_commissioned,
         coalesce(d.total_downtime_minutes, 0) as total_downtime_minutes
     from span_port_days as s
     left join downtime_agg as d
-        on s.charger_id = d.charger_id
-       and s.port_id = d.port_id
+        on s.port_key = d.port_key
        and s.date_id = d.date_id
 )
 
 select
     {{ dbt_utils.generate_surrogate_key(['charger_id', 'port_id', 'date_id']) }} as uptime_id,
     charger_id,
+    port_key,
     port_id,
     date_id,
     (minutes_commissioned - total_downtime_minutes) / minutes_commissioned as uptime

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -430,7 +430,11 @@ new_visits as (
 {% endif %}
 
 select
+    {{ dbt_utils.generate_surrogate_key([
+        'v.location_id', 'v.first_charger_id', 'v.first_port_id', 'v.visit_start_ts'
+    ]) }} as visit_id,
     dl.location_key,
+    dd.driver_key,
     v.location_id,
     v.charger_ids,
     v.id_tag,
@@ -448,10 +452,6 @@ select
     v.is_successful,
     v.grouping_key,
     {{ dbt.datediff('v.visit_start_ts', 'v.visit_end_ts', 'minute') }} as visit_duration_minutes,
-    {{ dbt_utils.generate_surrogate_key([
-        'v.location_id', 'v.first_charger_id', 'v.first_port_id', 'v.visit_start_ts'
-    ]) }} as visit_id,
-    dd.driver_key,
     (select incremental_ts from incremental) as incremental_ts
 from visits as v
 inner join {{ ref('dim_locations') }} as dl

--- a/models/marts/fact_visits.sql
+++ b/models/marts/fact_visits.sql
@@ -430,27 +430,32 @@ new_visits as (
 {% endif %}
 
 select
-    {{ dbt_utils.generate_surrogate_key(['location_id']) }} as location_key,
-    location_id,
-    charger_ids,
-    id_tag,
-    visit_start_ts,
-    visit_end_ts,
-    charge_attempt_count,
-    charge_attempt_ids,
-    total_energy_transferred_kwh,
-    first_charge_attempt_id,
-    last_charge_attempt_id,
-    first_charger_id,
-    last_charger_id,
-    first_port_id,
-    last_port_id,
-    is_successful,
-    grouping_key,
-    {{ dbt.datediff('visit_start_ts', 'visit_end_ts', 'minute') }} as visit_duration_minutes,
+    dl.location_key,
+    v.location_id,
+    v.charger_ids,
+    v.id_tag,
+    v.visit_start_ts,
+    v.visit_end_ts,
+    v.charge_attempt_count,
+    v.charge_attempt_ids,
+    v.total_energy_transferred_kwh,
+    v.first_charge_attempt_id,
+    v.last_charge_attempt_id,
+    v.first_charger_id,
+    v.last_charger_id,
+    v.first_port_id,
+    v.last_port_id,
+    v.is_successful,
+    v.grouping_key,
+    {{ dbt.datediff('v.visit_start_ts', 'v.visit_end_ts', 'minute') }} as visit_duration_minutes,
     {{ dbt_utils.generate_surrogate_key([
-        'location_id', 'first_charger_id', "first_port_id", 'visit_start_ts'
+        'v.location_id', 'v.first_charger_id', 'v.first_port_id', 'v.visit_start_ts'
     ]) }} as visit_id,
-    {{ dbt_utils.generate_surrogate_key(["coalesce(id_tag, 'UNKNOWN')"]) }} as driver_key,
+    dd.driver_key,
     (select incremental_ts from incremental) as incremental_ts
-from visits
+from visits as v
+inner join {{ ref('dim_locations') }} as dl
+    on v.location_id = dl.location_id
+left join {{ ref('dim_drivers') }} as dd
+    on coalesce(v.id_tag, 'UNKNOWN') = dd.id_tag
+

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -169,6 +169,14 @@ models:
         description: "Identifier for the charger"
         data_tests:
           - not_null
+      - name: port_key
+        description: "Foreign key to dim_ports for the affected port."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_ports')
+                field: port_key
       - name: port_id
         description: "Port identifier associated with the charger (may be null if unavailable)"
       - name: duration_minutes
@@ -569,6 +577,14 @@ models:
         description: "Charger identifier"
         data_tests:
           - not_null
+      - name: port_key
+        description: "Foreign key to dim_ports. Surrogate key read from dim_ports."
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_ports')
+                field: port_key
       - name: port_id
         description: "Port identifier within the charger"
         data_tests:

--- a/models/marts/unit_tests.yml
+++ b/models/marts/unit_tests.yml
@@ -103,6 +103,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 2, total_energy_transferred_kwh: 11.7}
@@ -178,6 +188,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 1}
@@ -254,6 +274,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 1}
@@ -330,6 +360,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: null, charge_attempt_count: 1}
@@ -404,6 +444,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: null, charge_attempt_count: 2}
@@ -479,6 +529,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: null, charge_attempt_count: 1}
@@ -555,6 +615,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 2}
@@ -630,6 +700,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: null, charge_attempt_count: 1}
@@ -762,6 +842,16 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 4}
@@ -834,9 +924,20 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: 'TAG-001', charge_attempt_count: 2, total_energy_transferred_kwh: 11.7, visit_start_ts: '2025-10-02 10:00:00', visit_end_ts: '2025-10-02 10:20:00', visit_duration_minutes: 20, first_charge_attempt_id: 'CHA1', last_charge_attempt_id: 'CHA2', first_charger_id: 'CH-001', last_charger_id: 'CH-002', first_port_id: '1', last_port_id: '1', incremental_ts: '2025-10-02 10:15:00'}
+
   
   - name: test_incremental_unauthorized_visit_merge
     description: "An unauthorized visit from a previous batch that continues in a new batch should merge into one visit"
@@ -905,6 +1006,19 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
+
+
+
     expect:
       rows:
         - {location_id: 'LOC-001', id_tag: null, charge_attempt_count: 2, total_energy_transferred_kwh: 5.5, visit_start_ts: '2025-10-02 11:00:00', visit_end_ts: '2025-10-02 11:01:30', visit_duration_minutes: 1, first_charge_attempt_id: 'CHA1', last_charge_attempt_id: 'CHA2', first_charger_id: 'CH-001', last_charger_id: 'CH-001', first_port_id: '1', last_port_id: '1', incremental_ts: '2025-10-02 11:01:00'} 
@@ -977,6 +1091,19 @@ unit_tests:
       - input: ref('dim_chargers')
         format: sql
         fixture: dim_chargers_fixture
+      - input: ref('dim_locations')
+        format: dict
+        rows:
+          - {location_key: 'location-key-001', location_id: 'LOC-001'}
+          - {location_key: 'location-key-002', location_id: 'LOC-002'}
+      - input: ref('dim_drivers')
+        format: dict
+        rows:
+          - {driver_key: 'driver-key-001', id_tag: 'TAG-001'}
+          - {driver_key: 'driver-key-unknown', id_tag: 'UNKNOWN'}
+
+
+
     expect:
       rows:
         - {id_tag: 'TAG-001', charge_attempt_count: 2}
@@ -1366,10 +1493,14 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charger_id, cast('2025-10-01 10:30:00' as timestamp) as from_ts, cast('2025-10-01 12:30:00' as timestamp) as to_ts, 120 as duration_minutes, cast('2025-10-01 12:30:00' as timestamp) as incremental_ts
+      - input: ref('dim_chargers')
+        format: sql
+        rows: |
+          select 'charger-key-001' as charger_key, 'CH-001' as charger_id, 'LOC-001' as location_id, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts, true as is_commissioned, 1 as port_count
       - input: ref('dim_ports')
         format: sql
         rows: |
-          select 'CH-001' as charger_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
+          select 'port-key-001' as port_key, 'CH-001' as charger_id, 'PORT-001' as port_id, 1 as connector_count
       - input: ref('dim_dates')
         format: sql
         rows: |
@@ -1395,10 +1526,14 @@ unit_tests:
         format: sql
         rows: |
           select 'CH-001' as charger_id, cast('2025-10-01 22:00:00' as timestamp) as from_ts, cast('2025-10-02 04:00:00' as timestamp) as to_ts, 360 as duration_minutes, cast('2025-10-02 12:00:00' as timestamp) as incremental_ts
+      - input: ref('dim_chargers')
+        format: sql
+        rows: |
+          select 'charger-key-001' as charger_key, 'CH-001' as charger_id, 'LOC-001' as location_id, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts, true as is_commissioned, 1 as port_count
       - input: ref('dim_ports')
         format: sql
         rows: |
-          select 'CH-001' as charger_id, 'LOC-001' as location_id, 'PORT-001' as port_id, '1' as connector_id, 'CCS' as connector_type, cast('2025-01-01' as timestamp) as commissioned_ts, cast(null as timestamp) as decommissioned_ts
+          select 'port-key-001' as port_key, 'CH-001' as charger_id, 'PORT-001' as port_id, 1 as connector_count
       - input: ref('dim_dates')
         format: sql
         rows: |


### PR DESCRIPTION
## Adds dimension keys to facts. 

### Follows one naming rule everywhere

natural business identifiers: charger_id, port_id
dimension foreign keys where helpful: port_key
fact row identifiers: visit_id, downtime_id, uptime_id

- it distinguishes a dimension join key from a fact row identifier
- it makes star-schema joins easier to read
- it avoids ambiguity when a fact also carries natural business IDs like charger_id, port_id

A useful mental model:
- _key = "join me to a dimension" (surrogate FK, owned and computed by the dimension)
- _id = "this row's identifier at this model's grain" (the fact's own surrogate PK)

### Column ordering

Every fact now leads with _id, then its _keys, then everything else:

<fact>_id, <dim>_key, ..., <dim>_key, <business columns...>

- fact_downtime_daily: downtime_id, port_key, ...
- fact_uptime: uptime_id, port_key, ...
- fact_visits: visit_id, location_key, driver_key, ...
- fact_charge_attempts / fact_interval_data: no dimension keys yet, so just their own _id moved to the front for consistency.

### Keys are computed once, in the dimension

Previously facts recomputed the same dbt_utils.generate_surrogate_key(...) hash the owning dimension already computes — deterministic, so it produced the right value, but duplicated in the wrong layer. Facts now join to the dimension and take its key as-is instead of rederiving it:

- fact_downtime_daily / fact_uptime join dim_ports for port_key
- fact_visits joins dim_locations for location_key and dim_drivers for driver_key

One source of truth per key; facts just reuse it.