### PR TITLE
Fix nullable port_id in fact_downtime_daily grain and docs (closes #102, #103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Writing style
+
+- Do not use em-dashes or "->" style arrows in any output text (responses, issue descriptions, PR descriptions, commit messages, docs). GitHub cannot read them. Use a regular hyphen (-) instead, or rephrase with "to", "then", or separate sentences.
+
 ## What this project is
 
 **kwwhat** is a dbt project that transforms raw OCPP (Open Charge Point Protocol) 1.6 logs into EV charger reliability and utilization metrics. It models uptime, charge attempt success, and driver visit outcomes.

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -159,7 +159,7 @@ models:
               - meter_15min_interval_start
 
   - name: fact_downtime_daily
-    description: "Daily aggregation of downtime at Port grain (charger_id + port_id + date_id). Splits outages across calendar days. Reliability metrics are tracked per Port — the independently operated unit that serves one EV at a time. Currently covers OFFLINE and FAULTED outage types."
+    description: "One row per date_id + charger_id + port_id + reason. Daily aggregation of downtime at Port grain, splitting outages across calendar days. Reliability metrics are tracked per Port — the independently operated unit that serves one EV at a time. Currently covers OFFLINE and FAULTED outage types. Both outage sources are inner-joined to dim_ports before reaching this model, so port_id is always populated."
     columns:
       - name: date_id
         description: "Calendar date for the downtime aggregation"
@@ -178,7 +178,9 @@ models:
                 to: ref('dim_ports')
                 field: port_key
       - name: port_id
-        description: "Port identifier associated with the charger (may be null if unavailable)"
+        description: "Port identifier associated with the charger. Always populated: both the OFFLINE and FAULTED outage sources are inner-joined to dim_ports before reaching this model."
+        data_tests:
+          - not_null
       - name: duration_minutes
         description: "Total downtime minutes for the date/charger/port combination"
         data_tests:


### PR DESCRIPTION
Closes #102, #103

- Removed the stale "may be null if unavailable" description on fact_downtime_daily.port_id. Tracing the SQL confirms port_id can never be null: both the OFFLINE and FAULTED outage sources are inner-joined to int_ports before reaching this model.
- Added a not_null test on port_id to enforce and document that constraint going forward.
- Updated the fact_downtime_daily model description to state its grain explicitly ("One row per date_id + charger_id + port_id + reason") and explain why port_id is always populated.
- No SQL or surrogate key changes were needed. A sentinel value for null port_id would have been dead code, since null never reaches this model with the current joins.
- Added a project-wide writing style rule to CLAUDE.md: no em-dashes or "->" arrows in generated text, since GitHub renders them incorrectly.

Test plan

- [x] Verified empirically that 0 of 11 existing rows in fact_downtime_daily had a null port_id
- [x] dbt build --select fact_downtime_daily passes (15/15: unit tests, data tests, including the new not_null_fact_downtime_daily_port_id)
- [x] dbt test --select fact_downtime_daily passes (14/14)

Notes

A related, separate gap was found (issue #146) during this investigation: connectorId=0 (charge-point-wide) Faulted status notifications are currently silently dropped in int_faulted_outages, undercounting downtime. That is a larger fix (new intermediate model, dedup logic against OFFLINE/FAULTED overlap) and is being filed as its own follow-up issue rather than bundled here.